### PR TITLE
Do not use templating in the binary name of the release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: secrethub
 
 builds:
-  - binary: "bin/{{ .ProjectName }}"
+  - binary: "bin/secrethub"
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This doesn't work for brew taps