### PR TITLE
 Release on Snapcraft 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
-  bin_directory: yes
+  bin_directory: true
   files:
   - LICENSE
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: secrethub
 
 builds:
-  - binary: "bin/secrethub"
+  - binary: "secrethub"
     env:
       - CGO_ENABLED=0
     goos:
@@ -25,6 +25,7 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
+  bin_directory: yes
   files:
   - LICENSE
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,3 +41,8 @@ brew:
 
   homepage: https://secrethub.io
   description: Command-line interface for SecretHub
+
+snapcraft:
+  publish: true
+  summary: Command-line interface for SecretHub
+  description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.


### PR DESCRIPTION
Release on [Snapcraft](https://snapcraft.io/).

See https://github.com/goreleaser/goreleaser/pull/1000 for adding the `bin_directory` option on the archive instead of setting it in the binary name.