### PR TITLE
 Request network and personal-files interfaces on the snap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,17 @@ snapcraft:
   publish: true
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.
+  apps:
+    secrethub-cli:
+      plugs:
+        - network
+        - personal-files
+  plugs:
+    personal-files:
+      read:
+        - $HOME/.secrethub
+      write:
+        - $HOME/.secrethub
 
 scoop:
   bucket:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ brew:
   description: Command-line interface for SecretHub
 
 snapcraft:
+  name: secrethub-cli
   publish: true
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.


### PR DESCRIPTION
The network interface is needed to communicate with the SecretHub API and the personal-files interface is needed to read/write the credential stored in `~/.secrethub`