### PR TITLE
Goreleaser: use secrethub as the snap package name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,12 +43,12 @@ brew:
   description: Command-line interface for SecretHub
 
 snapcraft:
-  name: secrethub-cli
+  name: secrethub
   publish: true
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.
   apps:
-    secrethub-cli:
+    secrethub:
       plugs:
         - network
         - personal-files


### PR DESCRIPTION
The snap name is also the name with which you call the command. This should be `secrethub`.