### PR TITLE
Release v0.21.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ snapcraft:
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.
   apps:
-    secrethub-cli:
+    secrethub:
       plugs:
         - network
 


### PR DESCRIPTION
# Changed

- Move snap from `secrethub` to `secrethub-cli`
- Add the binary in a bin dir in the archive for windows (as was the case before v0.21.0)

# Fixed

- Request network access for the snap