### PR TITLE
Goreleaser: request the home interface on snap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ snapcraft:
   apps:
     secrethub:
       plugs:
+        - home
         - network
 
 scoop:


### PR DESCRIPTION
The CLI sometimes has to read from and write to files in the users
home directory, for example to read template files and to write
injected files to disk.