### PR TITLE
Rename the scoop release to secrethub-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,7 @@ snapcraft:
         - network
 
 scoop:
+  name: secrethub-cli
   bucket:
     owner: secrethub
     name: scoop-secrethub


### PR DESCRIPTION
Use the same name for scoop as for other package managers.
This is also the name we have used in documentation.