### PR TITLE
Release v0.21.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ snapcraft:
   apps:
     secrethub:
       plugs:
+        - home
         - network
 
 scoop:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ snapcraft:
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts.
   apps:
-    secrethub-cli:
+    secrethub:
       plugs:
         - network
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,7 @@ snapcraft:
         - network
 
 scoop:
+  name: secrethub-cli
   bucket:
     owner: secrethub
     name: scoop-secrethub

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: secrethub
 
 builds:
-  - binary: "secrethub"
+  - binary: "bin/secrethub"
     env:
       - CGO_ENABLED=0
     goos:
@@ -25,7 +25,6 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
-  bin_directory: true
   files:
   - LICENSE
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,13 +50,6 @@ snapcraft:
     secrethub-cli:
       plugs:
         - network
-        - personal-files
-  plugs:
-    personal-files:
-      read:
-        - $HOME/.secrethub
-      write:
-        - $HOME/.secrethub
 
 scoop:
   bucket:


### PR DESCRIPTION
# Fixes

- Request the [home interface](https://docs.snapcraft.io/the-home-interface) on the snap release.
- Publish the scoop release as `secrethub-cli`