### PR TITLE
Make audit a root command

### DIFF
--- a/internals/secrethub/app.go
+++ b/internals/secrethub/app.go
@@ -125,10 +125,7 @@ func (app *App) Run(args []string) error {
 func (app *App) registerCommands() {
 	NewACLCommand(app.io, app.clientFactory.NewClient).Register(app.cli)
 	NewAccountCommand(app.io, app.clientFactory.NewClient, app.credentialStore).Register(app.cli)
-
-	auditCommand := app.cli.Command("audit", "Show the audit log of all actions on a repository or a secret.")
-	NewAuditCommand(app.io, app.clientFactory.NewClient).Register(auditCommand)
-
+	NewAuditCommand(app.io, app.clientFactory.NewClient).Register(app.cli)
 	NewClearCommand(app.io).Register(app.cli)
 	NewClearClipboardCommand().Register(app.cli)
 	NewConfigCommand(app.io, app.credentialStore).Register(app.cli)

--- a/internals/secrethub/app.go
+++ b/internals/secrethub/app.go
@@ -128,8 +128,6 @@ func (app *App) registerCommands() {
 
 	auditCommand := app.cli.Command("audit", "Show the audit log of all actions on a repository or a secret.")
 	NewAuditCommand(app.io, app.clientFactory.NewClient).Register(auditCommand)
-	NewAuditRepoCommand(app.io, app.clientFactory.NewClient).Register(auditCommand)
-	NewAuditSecretCommand(app.io, app.clientFactory.NewClient).Register(auditCommand)
 
 	NewClearCommand(app.io).Register(app.cli)
 	NewClearClipboardCommand().Register(app.cli)

--- a/internals/secrethub/audit.go
+++ b/internals/secrethub/audit.go
@@ -23,7 +23,7 @@ func NewAuditCommand(io ui.IO, newClient newClientFunc) *AuditCommand {
 
 // Register registers the command, arguments and flags on the provided Registerer.
 func (cmd *AuditCommand) Register(r Registerer) {
-	clause := r.Command("", "Show the audit log of all actions on a repository or a secret.")
+	clause := r.Command("audit", "Show the audit log of all actions on a repository or a secret.")
 	clause.Default()
 	clause.Arg("repo-path or secret-path", "Path to the repository or the secret to audit (<namespace>/<repo>[/<path>])").SetValue(&cmd.path)
 	registerTimestampFlag(clause).BoolVar(&cmd.useTimestamps)


### PR DESCRIPTION
- Removed the hidden `audit repo` and `audit secret` commands
- Made `audit` a root command, which fixes the help text