### PR TITLE
Add a default to secrethub run --template

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -61,7 +61,7 @@ func (cmd *RunCommand) Register(r Registerer) {
 	clause := r.Command("run", "Runs a program and passes environment variables to it, sourcing values from SecretHub.")
 	clause.Arg("command", "The command to execute").Required().StringsVar(&cmd.command)
 	clause.Flag("envar", "Source an environment variable from a secret at a given path with `NAME=<path>`").Short('e').StringMapVar(&cmd.envar)
-	clause.Flag("template", "The path to a .yml template file with environment variable mappings of the form `NAME: value`. Templates are automatically injected with secrets when referenced.").StringVar(&cmd.template)
+	clause.Flag("template", "The path to a .yml template file with environment variable mappings of the form `NAME: value`. Templates are automatically injected with secrets when referenced.").Default("secrethub-env.yml").StringVar(&cmd.template)
 	clause.Flag("env", "The name of the environment prepared by the set command (default is `default`)").Default("default").StringVar(&cmd.env)
 
 	BindAction(clause, cmd.Run)

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -61,7 +61,7 @@ func (cmd *RunCommand) Register(r Registerer) {
 	clause := r.Command("run", "Runs a program and passes environment variables to it, sourcing values from SecretHub.")
 	clause.Arg("command", "The command to execute").Required().StringsVar(&cmd.command)
 	clause.Flag("envar", "Source an environment variable from a secret at a given path with `NAME=<path>`").Short('e').StringMapVar(&cmd.envar)
-	clause.Flag("template", "The path to a .yml template file with environment variable mappings of the form `NAME: value`. Templates are automatically injected with secrets when referenced.").Default("secrethub-env.yml").StringVar(&cmd.template)
+	clause.Flag("template", "The path to a .yml template file with environment variable mappings of the form `NAME: value`. Templates are automatically injected with secrets when referenced.").StringVar(&cmd.template)
 	clause.Flag("env", "The name of the environment prepared by the set command (default is `default`)").Default("default").StringVar(&cmd.env)
 
 	BindAction(clause, cmd.Run)
@@ -79,6 +79,13 @@ func (cmd *RunCommand) Run() error {
 		return errio.Error(err)
 	}
 	envSources = append(envSources, flagSource)
+
+	if cmd.template == "" {
+		const defaultTemplate = "secrethub-env.yml"
+		if _, err := os.Stat(defaultTemplate); err == nil {
+			cmd.template = defaultTemplate
+		}
+	}
 
 	if cmd.template != "" {
 		file, err := ioutil.ReadFile(cmd.template)


### PR DESCRIPTION
This makes the default usage simpler.

The simple usecase should not require extra configuration. More complex projects that have multiple tempaltes, can configure them by supplying the flag.