### PR TITLE
Don't make audit the default command

### DIFF
--- a/internals/secrethub/audit.go
+++ b/internals/secrethub/audit.go
@@ -24,7 +24,6 @@ func NewAuditCommand(io ui.IO, newClient newClientFunc) *AuditCommand {
 // Register registers the command, arguments and flags on the provided Registerer.
 func (cmd *AuditCommand) Register(r Registerer) {
 	clause := r.Command("audit", "Show the audit log of all actions on a repository or a secret.")
-	clause.Default()
 	clause.Arg("repo-path or secret-path", "Path to the repository or the secret to audit (<namespace>/<repo>[/<path>])").SetValue(&cmd.path)
 	registerTimestampFlag(clause).BoolVar(&cmd.useTimestamps)
 


### PR DESCRIPTION
The default command is executed when no command is supplied
(running secrethub without args in this case). This was used on
the audit command when it was a subcommand of audit. Now that
audit is a root command, we no longer want it to be the default.

Running secrethub without a command prints the help text.