### PR TITLE
Mask secrets on stdout and stderr with secrethub run

### DIFF
--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -1,3 +1,4 @@
+// Package masker provides a wrapper around an io.Writer that replaces sensitive values in its output.
 package masker
 
 import (
@@ -6,6 +7,7 @@ import (
 	"time"
 )
 
+// Matcher is an interface used by MaskedWriter to find matches of sequences to mask.
 type Matcher interface {
 	Read(byte) int
 	InProgress() bool
@@ -111,7 +113,7 @@ func NewMaskedWriter(w io.Writer, masks [][]byte, maskString string, timeout tim
 	}
 }
 
-// Write implements implements to Write from io.Writer
+// Write implements to Write from io.Writer
 // It is responsible for finding any matches to mask and mark the appropriate bytes as masked.
 // This function never returns an error. These can instead be caught with Flush().
 func (mw *MaskedWriter) Write(p []byte) (n int, err error) {
@@ -150,7 +152,7 @@ func (mw *MaskedWriter) flushBuffer() {
 	mw.buf = mw.buf[:0]
 }
 
-// Run writes any data processed data from the output channel to the underlying io.Writer.
+// Run writes any processed data from the output channel to the underlying io.Writer.
 // If no new data is received on the output channel for Timeout, the output buffer is forced flushed
 // and all ongoing matches are reset.
 //

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -32,7 +32,7 @@ func (m *sequenceMatcher) Read(in byte) int {
 		return 0
 	}
 
-	m.findShift()
+	m.currentIndex -= m.findShift()
 
 	if m.sequence[m.currentIndex] == in {
 		return m.Read(in)
@@ -44,7 +44,7 @@ func (m *sequenceMatcher) Read(in byte) int {
 // findShift checks whether we can also make a partial match by decreasing the currentIndex .
 // For example, if the sequence is foofoobar, if someone inserts foofoofoobar, we still want to match.
 // So after the third f is inserted, the currentIndex is decreased by 3 with the following code.
-func (m *sequenceMatcher) findShift() {
+func (m *sequenceMatcher) findShift() int {
 	for offset := 1; offset <= m.currentIndex; offset++ {
 		ok := true
 		for i := 0; i < m.currentIndex-offset; i++ {
@@ -54,10 +54,10 @@ func (m *sequenceMatcher) findShift() {
 			}
 		}
 		if ok {
-			m.currentIndex -= offset
-			return
+			return offset
 		}
 	}
+	return m.currentIndex
 }
 
 // InProgress returns whether this sequenceMatcher is currently partially matching.

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -1,0 +1,204 @@
+package masker
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+type Matcher interface {
+	Read(byte) int
+	InProgress() bool
+	Reset()
+}
+
+type sequenceMatcher struct {
+	sequence     []byte
+	currentIndex int
+}
+
+// Read takes in a new byte to match against.
+// If the given byte results in a match with sequence, the number of matched bytes is returned.
+func (m *sequenceMatcher) Read(in byte) int {
+	if m.sequence[m.currentIndex] == in {
+		m.currentIndex++
+
+		if m.currentIndex == len(m.sequence) {
+			m.currentIndex = 0
+			return len(m.sequence)
+		}
+		return 0
+	}
+
+	m.findShift()
+
+	if m.sequence[m.currentIndex] == in {
+		return m.Read(in)
+	}
+	m.currentIndex = 0
+	return 0
+}
+
+// findShift checks whether we can also make a partial match by decreasing the currentIndex .
+// For example, if the sequence is foofoobar, if someone inserts foofoofoobar, we still want to match.
+// So after the third f is inserted, the currentIndex is decreased by 3 with the following code.
+func (m *sequenceMatcher) findShift() {
+	for offset := 1; offset <= m.currentIndex; offset++ {
+		ok := true
+		for i := 0; i < m.currentIndex-offset; i++ {
+			if m.sequence[i] != m.sequence[i+offset] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			m.currentIndex -= offset
+			return
+		}
+	}
+}
+
+// InProgress returns whether this sequenceMatcher is currently partially matching.
+//
+// For example, if the sequence is "foobar" and the registered input is "foob", InProgress() returns true.
+func (m *sequenceMatcher) InProgress() bool {
+	return m.currentIndex > 0
+}
+
+// Reset forgets the current match.
+func (m *sequenceMatcher) Reset() {
+	m.currentIndex = 0
+}
+
+// maskByte represents a byte and whether the byte should be masked or not.
+type maskByte struct {
+	byte
+	masked bool
+}
+
+// MaskedWriter wraps an io.Writer and masks all matches found by Matchers with MaskString.
+// If no write is made for Timeout on the io.Writer, any matches in progress are reset
+// and the buffer is flushed. This is to ensure that the writer does not hang on partial matches.
+type MaskedWriter struct {
+	w          io.Writer
+	MaskString string
+	Matchers   []Matcher
+	Timeout    time.Duration
+
+	buf    []maskByte
+	lock   *sync.Mutex
+	output chan []maskByte
+	err    error
+	nIn    int64
+	nOut   int64
+}
+
+func NewMaskedWriter(w io.Writer, masks [][]byte, maskString string, timeout time.Duration) *MaskedWriter {
+	var lock sync.Mutex
+	matchers := make([]Matcher, len(masks))
+	for _, mask := range masks {
+		matchers = append(matchers, &sequenceMatcher{
+			sequence: mask,
+		})
+	}
+	return &MaskedWriter{
+		w:          w,
+		MaskString: maskString,
+		Matchers:   matchers,
+		Timeout:    timeout,
+		lock:       &lock,
+		output:     make(chan []maskByte, 1),
+	}
+}
+
+// Write implements implements to Write from io.Writer
+// It is responsible for finding any matches to mask and mark the appropriate bytes as masked.
+// This function never returns an error. These can instead be caught with Flush().
+func (mw *MaskedWriter) Write(p []byte) (n int, err error) {
+	for _, b := range p {
+		matchInProgress := false
+
+		mw.lock.Lock()
+		mw.buf = append(mw.buf, maskByte{byte: b})
+
+		for _, matcher := range mw.Matchers {
+			maskLen := matcher.Read(b)
+			for i := 0; i < maskLen; i++ {
+				mw.buf[len(mw.buf)-1-i].masked = true
+			}
+			matchInProgress = matchInProgress || matcher.InProgress()
+		}
+
+		if !matchInProgress {
+			mw.flushBuffer()
+		} else {
+			mw.output <- []maskByte{}
+		}
+
+		mw.lock.Unlock()
+	}
+
+	mw.nIn += int64(len(p))
+
+	return len(p), nil
+}
+
+func (mw *MaskedWriter) flushBuffer() {
+	tmp := make([]maskByte, len(mw.buf))
+	copy(tmp, mw.buf)
+	mw.output <- tmp
+	mw.buf = mw.buf[:0]
+}
+
+// Run writes any data processed data from the output channel to the underlying io.Writer.
+// If no new data is received on the output channel for Timeout, the output buffer is forced flushed
+// and all ongoing matches are reset.
+//
+// This should be run in a seperate goroutine.
+func (mw *MaskedWriter) Run() {
+	masking := false
+	for {
+		select {
+		case <-time.After(mw.Timeout):
+			mw.lock.Lock()
+			if len(mw.output) == 0 {
+				for _, matcher := range mw.Matchers {
+					matcher.Reset()
+				}
+				mw.flushBuffer()
+			}
+			mw.lock.Unlock()
+		case output := <-mw.output:
+			for _, b := range output {
+				var err error
+				if b.masked {
+					if !masking {
+						_, err = mw.w.Write([]byte(mw.MaskString))
+						if err != nil {
+							mw.err = err
+							return
+						}
+					}
+					masking = true
+				} else {
+					_, err = mw.w.Write([]byte{b.byte})
+					if err != nil {
+						mw.err = err
+						return
+					}
+					masking = false
+				}
+			}
+			mw.nOut += int64(len(output))
+		}
+	}
+}
+
+// Flush is called to make sure that all output is written to the underlying io.Writer.
+// Returns any errors caused by the writing.
+func (mw *MaskedWriter) Flush() error {
+	for mw.nIn != mw.nOut && mw.err == nil {
+		time.Sleep(time.Microsecond)
+	}
+	return mw.err
+}

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -154,7 +154,7 @@ func (mw *MaskedWriter) flushBuffer() {
 // If no new data is received on the output channel for Timeout, the output buffer is forced flushed
 // and all ongoing matches are reset.
 //
-// This should be run in a seperate goroutine.
+// This should be run in a separate goroutine.
 func (mw *MaskedWriter) Run() {
 	masking := false
 	for {

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -33,11 +33,9 @@ func (m *sequenceMatcher) Read(in byte) int {
 	}
 
 	m.currentIndex -= m.findShift()
-
 	if m.sequence[m.currentIndex] == in {
 		return m.Read(in)
 	}
-	m.currentIndex = 0
 	return 0
 }
 

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -133,8 +133,6 @@ func (mw *MaskedWriter) Write(p []byte) (n int, err error) {
 
 		if !matchInProgress {
 			mw.flushBuffer()
-		} else {
-			mw.output <- []maskByte{}
 		}
 
 		mw.lock.Unlock()

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -113,7 +113,7 @@ func NewMaskedWriter(w io.Writer, masks [][]byte, maskString string, timeout tim
 	}
 }
 
-// Write implements to Write from io.Writer
+// Write implements Write from io.Writer
 // It is responsible for finding any matches to mask and mark the appropriate bytes as masked.
 // This function never returns an error. These can instead be caught with Flush().
 func (mw *MaskedWriter) Write(p []byte) (n int, err error) {

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -96,10 +96,10 @@ type MaskedWriter struct {
 func NewMaskedWriter(w io.Writer, masks [][]byte, maskString string, timeout time.Duration) *MaskedWriter {
 	var lock sync.Mutex
 	matchers := make([]Matcher, len(masks))
-	for _, mask := range masks {
-		matchers = append(matchers, &sequenceMatcher{
+	for i, mask := range masks {
+		matchers[i] = &sequenceMatcher{
 			sequence: mask,
-		})
+		}
 	}
 	return &MaskedWriter{
 		w:          w,

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -182,7 +182,7 @@ func TestNewMaskedWriter(t *testing.T) {
 			},
 			expected: maskString + " " + maskString + " fo",
 		},
-		"within Timeout": {
+		"within timeout": {
 			maskStrings: []string{"foo", "bar"},
 			inputFunc: func(w io.Writer) {
 				_, err := w.Write([]byte("fo"))
@@ -194,7 +194,7 @@ func TestNewMaskedWriter(t *testing.T) {
 			timeout:  &timeout20ms,
 			expected: maskString + " test",
 		},
-		"outside Timeout": {
+		"outside timeout": {
 			maskStrings: []string{"foo", "bar"},
 			inputFunc: func(w io.Writer) {
 				_, err := w.Write([]byte("fo"))

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -1,0 +1,257 @@
+package masker
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+)
+
+func TestMatcher(t *testing.T) {
+	tests := []struct {
+		matchString     string
+		input           string
+		useReset        bool
+		resetIndex      int
+		expectedMatches []int
+	}{
+		{
+			matchString:     "test",
+			input:           "test",
+			expectedMatches: []int{0},
+		},
+		{
+			matchString:     "test",
+			input:           "ttest",
+			expectedMatches: []int{1},
+		},
+		{
+			matchString:     "test",
+			input:           "testtest",
+			expectedMatches: []int{0, 4},
+		},
+		{
+			matchString:     "testtest",
+			input:           "test",
+			expectedMatches: nil,
+		},
+		{
+			matchString:     "foofoobar",
+			input:           "foofoofoobar",
+			expectedMatches: []int{3},
+		},
+		{
+			matchString:     "test",
+			input:           "123 testtest",
+			expectedMatches: []int{4, 8},
+		},
+		{
+			matchString:     "test",
+			input:           "t est",
+			expectedMatches: nil,
+		},
+		{
+			matchString:     "test",
+			input:           "tesat",
+			expectedMatches: nil,
+		},
+		{
+			matchString:     "test",
+			input:           "tesT",
+			expectedMatches: nil,
+		},
+		{
+			matchString:     "t",
+			input:           "ttattt",
+			expectedMatches: []int{0, 1, 3, 4, 5},
+		},
+		{
+			matchString:     "tt",
+			input:           "ttattt",
+			expectedMatches: []int{0, 3},
+		},
+		{
+			matchString:     "test",
+			input:           "test",
+			useReset:        true,
+			resetIndex:      0,
+			expectedMatches: []int{0},
+		},
+		{
+			matchString:     "test",
+			input:           "test",
+			useReset:        true,
+			resetIndex:      1,
+			expectedMatches: nil,
+		},
+		{
+			matchString:     "test",
+			input:           "testtest",
+			useReset:        true,
+			resetIndex:      1,
+			expectedMatches: []int{4},
+		},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf("%s in %s", tc.matchString, tc.input)
+
+		t.Run(name, func(t *testing.T) {
+			matcher := sequenceMatcher{sequence: []byte(tc.matchString)}
+			var matches []int
+			for i, b := range []byte(tc.input) {
+				if tc.useReset && tc.resetIndex == i {
+					matcher.Reset()
+				}
+
+				matchedBytes := matcher.Read(b)
+				if matchedBytes > 0 {
+					matches = append(matches, i-len(tc.matchString)+1)
+				}
+			}
+			assert.Equal(t, matches, tc.expectedMatches)
+		})
+	}
+
+}
+
+func TestNewMaskedWriter(t *testing.T) {
+	maskString := "<redacted by SecretHub>"
+
+	timeout20ms := time.Millisecond * 20
+	timeout1ms := time.Millisecond * 1
+
+	tests := map[string]struct {
+		maskStrings []string
+		inputFunc   func(io.Writer)
+		timeout     *time.Duration
+		expected    string
+	}{
+		"no_masking": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("test"))
+				assert.OK(t, err)
+			},
+			expected: "test",
+		},
+		"single mask": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("test foo test"))
+				assert.OK(t, err)
+			},
+			expected: "test " + maskString + " test",
+		},
+		"multiple masks": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("test foo bar"))
+				assert.OK(t, err)
+			},
+			expected: "test " + maskString + " " + maskString,
+		},
+		"incomplete mask": {
+			maskStrings: []string{"foobar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("test foo"))
+				assert.OK(t, err)
+			},
+			expected: "test foo",
+		},
+		"mask within a mask": {
+			maskStrings: []string{"foo", "bar", "testfoobartestfoo"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("testfoobartestfoo bar foo"))
+				assert.OK(t, err)
+			},
+			expected: maskString + " " + maskString + " " + maskString,
+		},
+		"across multiple writes": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("fo"))
+				assert.OK(t, err)
+				_, err = w.Write([]byte("o bar f"))
+				assert.OK(t, err)
+				_, err = w.Write([]byte("o"))
+				assert.OK(t, err)
+			},
+			expected: maskString + " " + maskString + " fo",
+		},
+		"within Timeout": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("fo"))
+				assert.OK(t, err)
+				time.Sleep(time.Millisecond * 5)
+				_, err = w.Write([]byte("o test"))
+				assert.OK(t, err)
+			},
+			timeout:  &timeout20ms,
+			expected: maskString + " test",
+		},
+		"outside Timeout": {
+			maskStrings: []string{"foo", "bar"},
+			inputFunc: func(w io.Writer) {
+				_, err := w.Write([]byte("fo"))
+				assert.OK(t, err)
+				time.Sleep(time.Millisecond * 2)
+				_, err = w.Write([]byte("o bar test"))
+				assert.OK(t, err)
+			},
+			timeout:  &timeout1ms,
+			expected: "foo " + maskString + " test",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			timeout := time.Millisecond * 10
+			if tc.timeout != nil {
+				timeout = *tc.timeout
+			}
+
+			var maskStrings [][]byte
+			for _, s := range tc.maskStrings {
+				maskStrings = append(maskStrings, []byte(s))
+			}
+
+			w := NewMaskedWriter(&buf, maskStrings, maskString, timeout)
+
+			go w.Run()
+			tc.inputFunc(w)
+
+			err := w.Flush()
+
+			assert.OK(t, err)
+			assert.Equal(t, tc.expected, buf.String())
+		})
+	}
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write(p []byte) (n int, err error) {
+	return 0, w.err
+}
+
+func TestNewMaskedWriter_WriteError(t *testing.T) {
+	expectedErr := fmt.Errorf("test")
+
+	w := NewMaskedWriter(&errWriter{err: expectedErr}, [][]byte{[]byte("a")}, "aa", time.Millisecond)
+
+	go w.Run()
+	_, err := w.Write([]byte{0x01})
+	assert.OK(t, err)
+
+	err = w.Flush()
+	assert.Equal(t, err, expectedErr)
+}

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -189,7 +189,7 @@ func (cmd *RunCommand) Run() error {
 		select {
 		case s := <-signals:
 			err := command.Process.Signal(s)
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "process already finished") {
 				fmt.Fprintln(os.Stderr, ErrSignalFailed(err))
 			}
 		case <-done:

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -39,7 +39,7 @@ var (
 	ErrEnvFileFormat  = errRun.Code("invalid_env_file_format").ErrorPref("env-file templates must be a valid yaml file with a map of string key and value pairs: %v")
 )
 
-var (
+const (
 	maskString = "<redacted by SecretHub>"
 )
 
@@ -232,11 +232,11 @@ func (cmd *RunCommand) Run() error {
 	if !cmd.noMasking {
 		err = maskedStdout.Flush()
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 		err = maskedStderr.Flush()
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -175,8 +175,10 @@ func (cmd *RunCommand) Run() error {
 	}
 
 	maskStrings := make([][]byte, len(secrets))
+	i := 0
 	for _, val := range secrets {
-		maskStrings = append(maskStrings, val)
+		maskStrings[i] = val
+		i++
 	}
 
 	maskedStdOut := masker.NewMaskedWriter(os.Stdout, maskStrings, maskString, time.Millisecond*500)


### PR DESCRIPTION
Add secret masking functionality to `secrethub run`. By default all secrets will be masked in `stdout` and `stderr`. If these values are detected, they are replaced with `<redacted by SecretHub>`.

This can be disabled with the `--no-masking`-flag.

A separate goroutine with `MaskedWriter.Run()` is used to write masked content to the underlying `io.Writer`. This is done to support staggered writes: if a secret is long and is split over multiple calls to `Write()`, we still want to be able to mask these values. Therefore the goroutine with `MaskedWriter.Run()` waits for `Timeout` for any subsequent writes.

## Example
```
$ secrethub write path/to/secret
Please type in the value of the secret, followed by an [ENTER]:

$ secrethub run --envar TEST=path/to/secret -- printenv | grep TEST
TEST=<redacted by SecretHub>
```
## Known "issues"

1. If a very low-entropy secret is masked, it might leak through the context of the output. For example, if a secret has as value `user` and the following text is outputted on stdout:
```
The username is: user
```
The following would be outputted after masking:
```
The <redacted by SecretHub>name is: <redacted by SecretHub>
```
This effectively leaks the value of the secret. However, in practice this should not be a real problem because any real secret should have high enough entropy to not show up in normal text.

2. If someone has control over the process ran with `secrethub run` _and_ the resulting masked logs, an oracle could be setup that leaks any secret by looking at the response time of the log output. However, if someone has access to the ran process, they would also have access to the environment containing the secrets.