### PR TITLE
Remove remaining CaptureErrorAndWait

### DIFF
--- a/cmd/secrethub/main.go
+++ b/cmd/secrethub/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/secrethub"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // These variables are set at compile-time using ldflags when creating a build.
@@ -28,10 +27,6 @@ func main() {
 func handleError(err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Encountered an error: %s\n", err)
-
-		// We need to block or we will exit before the bug report is sent.
-		errio.CaptureErrorAndWait(err, nil)
-
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is currently a noop as we no longer set a Sentry DSN. We do not track errors in the CLI.

`errio.CaptureErrorAndWait` was removed in [secrethub-go v0.19.0](https://github.com/secrethub/secrethub-go/pull/74). This change is required to update secrethub-go.