### PR TITLE
Add quote support to .ENV files

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -479,7 +479,7 @@ func parseEnv(raw string) ([]envvar, error) {
 		}
 
 		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
+		value := trimQuotes(strings.TrimSpace(parts[1]))
 
 		vars[key] = envvar{
 			key:        key,
@@ -496,6 +496,32 @@ func parseEnv(raw string) ([]envvar, error) {
 	}
 
 	return res, nil
+}
+
+const (
+	doubleQuoteChar = '\u0022'
+	singleQuoteChar = '\u0027'
+)
+
+// trimQuotes removes a leading and trailing quote from the given string value if
+// it is wrapped in either single or double quotes.
+//
+// Rules:
+// - Empty values become empty values (e.g. `''`and `""` both evaluate to the empty string ``).
+// - Inner quotes are maintained (e.g. `{"foo":"bar"}` remains unchanged).
+// - Single and double quoted values are escaped (e.g. `'foo'` and `"foo"` both evaluate to `foo`).
+// - Single and double qouted values maintain whitespace from both ends (e.g. `" foo "` becomes ` foo `)
+// - Inputs with either leading or trailing whitespace are considered unquoted,
+//   so make sure you sanitize your inputs before calling this function.
+func trimQuotes(s string) string {
+	n := len(s)
+	if n > 1 &&
+		(s[0] == singleQuoteChar && s[n-1] == singleQuoteChar ||
+			s[0] == doubleQuoteChar && s[n-1] == doubleQuoteChar) {
+		return s[1 : n-1]
+	}
+
+	return s
 }
 
 func parseYML(raw string) ([]envvar, error) {

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -478,8 +478,8 @@ func parseEnv(raw string) ([]envvar, error) {
 			return nil, ErrTemplate(i, errors.New("template is not formatted as key=value pairs"))
 		}
 
-		key := strings.TrimRight(parts[0], " ")
-		value := strings.TrimLeft(parts[1], " ")
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
 
 		vars[key] = envvar{
 			key:        key,

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -499,8 +499,8 @@ func parseEnv(raw string) ([]envvar, error) {
 }
 
 const (
-	doubleQuoteChar = '\u0022'
-	singleQuoteChar = '\u0027'
+	doubleQuoteChar = '\u0022' // "
+	singleQuoteChar = '\u0027' // '
 )
 
 // trimQuotes removes a leading and trailing quote from the given string value if

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -72,6 +72,16 @@ func TestParseEnv(t *testing.T) {
 				},
 			},
 		},
+		"success with tabs": {
+			raw: "key\t=\tvalue",
+			expected: []envvar{
+				{
+					key:        "key",
+					value:      "value",
+					lineNumber: 1,
+				},
+			},
+		},
 		"success comment": {
 			raw: "# database\nDB_USER = user\nDB_PASS = pass",
 			expected: []envvar{

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -96,9 +96,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: " key = value",
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 8,
 				},
 			},
 		},
@@ -106,9 +107,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "key = value ",
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 7,
 				},
 			},
 		},
@@ -116,9 +118,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "key\t=\tvalue",
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 7,
 				},
 			},
 		},
@@ -126,9 +129,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "key='value'",
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 6,
 				},
 			},
 		},
@@ -136,9 +140,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: `key="value"`,
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 6,
 				},
 			},
 		},
@@ -146,9 +151,10 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "key = 'value'",
 			expected: []envvar{
 				{
-					key:        "key",
-					value:      "value",
-					lineNumber: 1,
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 8,
 				},
 			},
 		},
@@ -156,14 +162,16 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "# database\nDB_USER = user\nDB_PASS = pass",
 			expected: []envvar{
 				{
-					key:        "DB_USER",
-					value:      "user",
-					lineNumber: 2,
+					key:          "DB_USER",
+					value:        "user",
+					lineNumber:   2,
+					columnNumber: 11,
 				},
 				{
-					key:        "DB_PASS",
-					value:      "pass",
-					lineNumber: 3,
+					key:          "DB_PASS",
+					value:        "pass",
+					lineNumber:   3,
+					columnNumber: 11,
 				},
 			},
 		},
@@ -171,14 +179,16 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "    # database\nDB_USER = user\nDB_PASS = pass",
 			expected: []envvar{
 				{
-					key:        "DB_USER",
-					value:      "user",
-					lineNumber: 2,
+					key:          "DB_USER",
+					value:        "user",
+					lineNumber:   2,
+					columnNumber: 11,
 				},
 				{
-					key:        "DB_PASS",
-					value:      "pass",
-					lineNumber: 3,
+					key:          "DB_PASS",
+					value:        "pass",
+					lineNumber:   3,
+					columnNumber: 11,
 				},
 			},
 		},
@@ -186,14 +196,16 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "\t# database\nDB_USER = user\nDB_PASS = pass",
 			expected: []envvar{
 				{
-					key:        "DB_USER",
-					value:      "user",
-					lineNumber: 2,
+					key:          "DB_USER",
+					value:        "user",
+					lineNumber:   2,
+					columnNumber: 11,
 				},
 				{
-					key:        "DB_PASS",
-					value:      "pass",
-					lineNumber: 3,
+					key:          "DB_PASS",
+					value:        "pass",
+					lineNumber:   3,
+					columnNumber: 11,
 				},
 			},
 		},
@@ -201,14 +213,16 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "foo=bar\n\nbar=baz",
 			expected: []envvar{
 				{
-					key:        "foo",
-					value:      "bar",
-					lineNumber: 1,
+					key:          "foo",
+					value:        "bar",
+					lineNumber:   1,
+					columnNumber: 5,
 				},
 				{
-					key:        "bar",
-					value:      "baz",
-					lineNumber: 3,
+					key:          "bar",
+					value:        "baz",
+					lineNumber:   3,
+					columnNumber: 5,
 				},
 			},
 		},
@@ -216,14 +230,16 @@ func TestParseDotEnv(t *testing.T) {
 			raw: "foo=bar\n    \nbar = baz",
 			expected: []envvar{
 				{
-					key:        "foo",
-					value:      "bar",
-					lineNumber: 1,
+					key:          "foo",
+					value:        "bar",
+					lineNumber:   1,
+					columnNumber: 5,
 				},
 				{
-					key:        "bar",
-					value:      "baz",
-					lineNumber: 3,
+					key:          "bar",
+					value:        "baz",
+					lineNumber:   3,
+					columnNumber: 7,
 				},
 			},
 		},
@@ -516,7 +532,7 @@ func TestTrimQuotes(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual := trimQuotes(tc.in)
+			actual, _ := trimQuotes(tc.in)
 
 			assert.Equal(t, actual, tc.expected)
 		})

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -72,6 +72,26 @@ func TestParseEnv(t *testing.T) {
 				},
 			},
 		},
+		"success with leading space": {
+			raw: " key = value",
+			expected: []envvar{
+				{
+					key:        "key",
+					value:      "value",
+					lineNumber: 1,
+				},
+			},
+		},
+		"success with trailing space": {
+			raw: "key = value ",
+			expected: []envvar{
+				{
+					key:        "key",
+					value:      "value",
+					lineNumber: 1,
+				},
+			},
+		},
 		"success with tabs": {
 			raw: "key\t=\tvalue",
 			expected: []envvar{
@@ -385,6 +405,10 @@ func TestTrimQuotes(t *testing.T) {
 			in:       `"foo"`,
 			expected: `foo`,
 		},
+		"maintain quotes inside unquoted value": {
+			in:       `{"foo":"bar"}`,
+			expected: `{"foo":"bar"}`,
+		},
 		"empty string": {
 			in:       "",
 			expected: "",
@@ -429,7 +453,6 @@ func TestTrimQuotes(t *testing.T) {
 			in:       `foo"`,
 			expected: `foo"`,
 		},
-
 		"single quoted with inner leading whitespace": {
 			in:       `' foo'`,
 			expected: ` foo`,


### PR DESCRIPTION
This makes the support similar to the [Node `dotenv` project](https://www.npmjs.com/package/dotenv#rules), which a lot of people are used to. The only feature we don't yet have is multiline support in quoted values, but we've decided to leave that for later. 

Also something to consider is how to handle quoted keys in the KEY=VALUE syntax. We can either pass them as is to the environment or ignore them and filter them out. IMO, passing them as is would be the simplest solution. 