### PR TITLE
Rework v2 secret templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/secrethub/secrethub-go v0.20.0
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,9 @@ github.com/secrethub/secrethub-go v0.20.0 h1:NK6G/c1QmmMI7Rwc5nntC66+x0WediVnxea
 github.com/secrethub/secrethub-go v0.20.0/go.mod h1:hfyfrv6v3kPkjOR/E8tEHgO3hxomrN37A59K/nXW0lw=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internals/cli/env_test.go
+++ b/internals/cli/env_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/secrethub/secrethub-go/internals/assert"
 )
 
 func TestSplitVar(t *testing.T) {

--- a/internals/secrethub/secret_reader.go
+++ b/internals/secrethub/secret_reader.go
@@ -1,0 +1,19 @@
+package secrethub
+
+import "github.com/secrethub/secrethub-go/pkg/secrethub"
+
+type secretReader struct {
+	client secrethub.Client
+}
+
+func newSecretReader(client secrethub.Client) secretReader {
+	return secretReader{client: client}
+}
+
+func (sr secretReader) ReadSecret(path string) (string, error) {
+	secret, err := sr.client.Secrets().Versions().GetWithData(path)
+	if err != nil {
+		return "", err
+	}
+	return string(secret.Data), nil
+}

--- a/internals/secrethub/tpl/fakes/secret_reader.go
+++ b/internals/secrethub/tpl/fakes/secret_reader.go
@@ -1,0 +1,17 @@
+package fakes
+
+import "errors"
+
+// FakeSecretReader implements tpl.SecretReader.
+type FakeSecretReader struct {
+	Secrets map[string]string
+}
+
+// ReadSecret implements tpl.SecretReader.ReadSecret.
+func (fsr FakeSecretReader) ReadSecret(path string) (string, error) {
+	secret, ok := fsr.Secrets[path]
+	if ok {
+		return secret, nil
+	}
+	return "", errors.New("secret not found")
+}

--- a/internals/secrethub/tpl/template.go
+++ b/internals/secrethub/tpl/template.go
@@ -1,21 +1,20 @@
 package tpl
 
+import "github.com/secrethub/secrethub-go/internals/errio"
+
+// Errors
+var (
+	tplError = errio.Namespace("template")
+)
+
 // Parser parses a raw string to a template.
 type Parser interface {
-	Parse(raw string) (VarTemplate, error)
+	Parse(raw string, column, line int) (Template, error)
 }
 
-// VarTemplate is a template containing variables. Once variables are injected,
-// secret paths can be retrieved and injected as well to retrieve the resulting string.
-type VarTemplate interface {
-	InjectVars(vars map[string]string) (SecretTemplate, error)
-}
-
-// SecretTemplate is a template containing secret paths. The plaintext values corresponding
-// to these paths can be injected to retrieve the resulting string.
-type SecretTemplate interface {
-	InjectSecrets(secrets map[string]string) (string, error)
-	Secrets() []string
+// Template contains secret and variable references. It can be evaluated to resolve to a string.
+type Template interface {
+	Evaluate(vars map[string]string, sr SecretReader) (string, error)
 }
 
 // NewParser returns a parser for the latest template syntax.

--- a/internals/secrethub/tpl/v1.go
+++ b/internals/secrethub/tpl/v1.go
@@ -2,12 +2,11 @@ package tpl
 
 import (
 	"github.com/secrethub/secrethub-cli/internals/tpl"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // Errors
 var (
-	ErrTemplateVarsNotSupported = errio.Namespace("template").Code("template_vars_not_supported").Error("the v1 template syntax does not support template variables")
+	ErrTemplateVarsNotSupported = tplError.Code("template_vars_not_supported").Error("the v1 template syntax does not support template variables")
 )
 
 // NewV1Parser returns a parser for the v1 template syntax.
@@ -28,7 +27,7 @@ type parserV1 struct{}
 
 // Parse parses a secret template from a raw string.
 // See tpl.Template for the format of the template.
-func (p parserV1) Parse(raw string) (VarTemplate, error) {
+func (p parserV1) Parse(raw string, _, _ int) (Template, error) {
 	t, err := tpl.NewParser("${", "}").Parse(raw)
 	if err != nil {
 		return nil, err
@@ -39,28 +38,22 @@ func (p parserV1) Parse(raw string) (VarTemplate, error) {
 	}, nil
 }
 
-// secretTemplateV1 is a template that only contains secret keys.
-type secretTemplateV1 struct {
-	template tpl.Template
-}
-
 // InjectVars takes a map of template variables with their corresponding values. It replaces
 // the template variables with their values in the template.
-func (t templateV1) InjectVars(vars map[string]string) (SecretTemplate, error) {
+func (t templateV1) Evaluate(vars map[string]string, sr SecretReader) (string, error) {
 	if len(vars) > 0 {
-		return nil, ErrTemplateVarsNotSupported
+		return "", ErrTemplateVarsNotSupported
 	}
 
-	return secretTemplateV1(t), nil
-}
+	keys := t.template.Keys()
+	secrets := make(map[string]string, len(keys))
+	for _, path := range keys {
+		secret, err := sr.ReadSecret(path)
+		if err != nil {
+			return "", err
+		}
+		secrets[path] = secret
+	}
 
-// InjectSecrets takes a map of secret paths with their corresponding values. It replaces
-// the secret paths with the corresponding values in the template.
-func (t secretTemplateV1) InjectSecrets(secrets map[string]string) (string, error) {
 	return t.template.Inject(secrets)
-}
-
-// Secrets returns a list of paths to secrets that are used in the template.
-func (t secretTemplateV1) Secrets() []string {
-	return t.template.Keys()
 }

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -1,9 +1,22 @@
 package tpl
 
 import (
-	"fmt"
+	"bytes"
+	"errors"
+	"io"
+	"unicode"
+)
 
-	"github.com/secrethub/secrethub-cli/internals/tpl"
+// Errors
+var (
+	ErrTemplateVarNotFound      = tplError.Code("template_var_not_found").ErrorPref("no value was supplied for template variable '%s'")
+	ErrUnexpectedDollar         = tplError.Code("unexpected_character").ErrorPref("unexpected '$' at line %d column %d. Use '\\$' if you want to output a dollar sign.")
+	ErrIllegalVariableCharacter = tplError.Code("illegal_variable_character").ErrorPref("Illegal character '%s' at line %d column %d. Variable names can only contain letters, digits and underscores.")
+	ErrIllegalSecretCharacter   = tplError.Code("illegal_secret_character").ErrorPref("Illegel character '%s' at line %d column %d. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.")
+	ErrSecretTagNotClosed       = tplError.Code("secret_tag_not_closed").ErrorPref("Expected the closing of a secret tag `}}` at line %d column %d, but reached the end of the template.")
+	ErrVariableTagNotClosed     = tplError.Code("variable_tag_not_closed").ErrorPref("Expected the closing of a variable tag `}` at line %d column %d, but reached the end of the template.")
+
+	specialChars = []rune{'$', '{', '}', '\\'}
 )
 
 // NewV2Parser returns a parser for the v2 template syntax.
@@ -24,95 +37,418 @@ func NewV2Parser() Parser {
 	return parserV2{}
 }
 
+type context struct {
+	vars         map[string]string
+	secretReader SecretReader
+}
+
+func (ctx context) secret(path string) (string, error) {
+	return ctx.secretReader.ReadSecret(path)
+}
+
+type node interface {
+	evaluate(ctx context) (string, error)
+}
+
+type secret struct {
+	path []node
+}
+
+func (s secret) evaluate(ctx context) (string, error) {
+	var buffer bytes.Buffer
+	for _, p := range s.path {
+		eval, err := p.evaluate(ctx)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(eval)
+	}
+	return ctx.secret(buffer.String())
+}
+
+type variable struct {
+	key string
+}
+
+func (v variable) evaluate(ctx context) (string, error) {
+	res, ok := ctx.vars[v.key]
+	if !ok {
+		return "", ErrTemplateVarNotFound(v.key)
+	}
+	return res, nil
+}
+
+type character rune
+
+func (c character) evaluate(ctx context) (string, error) {
+	return string(c), nil
+}
+
 type templateV2 struct {
-	template tpl.Template
-	// secrets is a map of template keys (can contain variables) and the corresponding
-	// template variable templates.
-	secrets map[string]tpl.Template
+	nodes []node
 }
 
 type parserV2 struct{}
 
 // Parse parses a secret template from a raw string.
-// See tpl.Template for the format of the template.
-func (p parserV2) Parse(raw string) (VarTemplate, error) {
-	t, err := tpl.NewParser("{{", "}}").Parse(raw)
+//
+// A secret template can contain references to secrets in secret tags.
+// A secret tag is enclosed in double brackets: `{{ <path> }}`.
+//
+// A secret template can contain references to variables in variable tags.
+// A variable tag is enclosed in `${ <variable key> }`.
+//
+// Secret tags can contain variable tags:
+// `{{ path/with/${var}/to/secret }}`
+//
+// Extra spaces can be added just after the opening delimiter and just before the closing delimiter of a tag:
+// {{ path/to/secret }} has the same output as {{path/to/secret}} has.
+//
+// Variable tags cannot contain secret tags.
+// Secret tags cannot contain secret tags (they cannot be nested).
+// Variable tags cannot contain variable tags (they cannot be nested).
+func (p parserV2) Parse(raw string, line, column int) (Template, error) {
+	parser := newV2Parser(bytes.NewBufferString(raw), line, column)
+	nodes, err := parser.parse()
+	if err != nil {
+		return nil, err
+	}
+	return templateV2{
+		nodes: nodes,
+	}, nil
+}
+
+func newV2Parser(buf *bytes.Buffer, line, column int) v2Parser {
+	return v2Parser{
+		buf:    buf,
+		lineNo: line,
+		// The column number indicates the index (starting at 1) of the current rune.
+		// We subtract 2 of the given value. One bacause we have not read the current rune yet and
+		// one more because we are reading the next rune in advance (which we don't want to count).
+		columnNo: column - 2,
+	}
+}
+
+type v2Parser struct {
+	buf      *bytes.Buffer
+	lineNo   int
+	columnNo int
+
+	current rune
+	next    rune
+}
+
+// readRune reads the next rune from the raw template.
+func (p *v2Parser) readRune() error {
+	p.current = p.next
+	if p.current == '\n' {
+		p.lineNo++
+		p.columnNo = 0
+	} else {
+		p.columnNo++
+	}
+
+	var err error
+	p.next, _, err = p.buf.ReadRune()
+	return err
+}
+
+func (p *v2Parser) parse() ([]node, error) {
+	res := []node{}
+	err := p.readRune()
+	if err == io.EOF {
+		return res, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	keys := t.Keys()
-
-	secrets := make(map[string]tpl.Template, len(keys))
-
-	templateVarParser := tpl.NewParser("${", "}")
-	for _, k := range keys {
-		parsed, err := templateVarParser.Parse(k)
+	for {
+		err := p.readRune()
+		if err == io.EOF {
+			return append(res, character(p.current)), nil
+		}
 		if err != nil {
 			return nil, err
 		}
-		secrets[k] = parsed
+
+		switch p.current {
+		case '$':
+			switch p.next {
+			case '{':
+				err = p.readRune()
+				if err == io.EOF {
+					return res, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				variable, err := p.parseVar()
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, variable)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				continue
+			default:
+				// We don't allow dollars before letters and underscores now,
+				// as we might want to use these for $var support (without brackets) later.
+				if unicode.IsLetter(p.next) || p.next == '_' {
+					return nil, ErrUnexpectedDollar(p.lineNo, p.columnNo)
+				}
+				res = append(res, character(p.current))
+				continue
+			}
+		case '{':
+			switch p.next {
+			case '{':
+				secret, err := p.parseSecret()
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, secret)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+				continue
+			default:
+				res = append(res, character(p.current))
+				continue
+			}
+		case '\\':
+			isSpecialChar := false
+			for _, specialChar := range specialChars {
+				if p.next == specialChar {
+					isSpecialChar = true
+					break
+				}
+			}
+			if isSpecialChar {
+				res = append(res, character(p.next))
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				res = append(res, character(p.current))
+			}
+			continue
+		default:
+			res = append(res, character(p.current))
+			continue
+		}
 	}
-
-	return templateV2{
-		template: t,
-		secrets:  secrets,
-	}, nil
 }
 
-// secretTemplateV2 is a template that only contains secret keys. Template variables
-// are already replaced.
-type secretTemplateV2 struct {
-	template tpl.Template
-	// secrets is a map of template keys (can contain variables) and the corresponding
-	// secret paths (with variables replaced by their values).
-	secrets map[string]string
-}
+// parseVar parses the contents of a template variable up to the closing delimiter.
+// parseVar should be called after the opening delimiter has been read. The next
+// character from the buffer should be the first character of the contents.
+//
+// when parseVar returns, the next character in the buffer is the first character
+// after the closing delimiter of the template variable.
+func (p *v2Parser) parseVar() (node, error) {
+	var buffer bytes.Buffer
 
-// InjectVars takes a map of template variables with their corresponding values. It replaces
-// the template variables with their values in the template.
-func (t templateV2) InjectVars(vars map[string]string) (SecretTemplate, error) {
-	secrets := make(map[string]string, len(t.secrets))
-	for k, template := range t.secrets {
-		secretpath, err := template.Inject(vars)
+	for p.next == ' ' {
+		err := p.readRune()
+		if err == io.EOF {
+			return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+		}
 		if err != nil {
 			return nil, err
 		}
-		secrets[k] = secretpath
 	}
 
-	return secretTemplateV2{
-		template: t.template,
-		secrets:  secrets,
-	}, nil
-}
+	for {
+		switch p.next {
+		case '}':
+			return variable{
+				key: buffer.String(),
+			}, nil
+		case ' ':
+			errIllegalVariableSpace := ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
+			err := p.forwardToClosing([]rune("}"))
+			if err == io.EOF {
+				return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+			}
+			if err != nil {
+				return nil, errIllegalVariableSpace
+			}
+			return variable{
+				key: buffer.String(),
+			}, nil
+		default:
+			if unicode.IsLetter(p.next) || unicode.IsDigit(p.next) || p.current == '_' {
+				buffer.WriteRune(p.next)
 
-// InjectSecrets takes a map of secret paths with their corresponding values. It replaces
-// the secret paths with the corresponding values in the template.
-func (t secretTemplateV2) InjectSecrets(secrets map[string]string) (string, error) {
-	keys := make(map[string]string, len(t.secrets))
-	for k, secretpath := range t.secrets {
-		v, ok := secrets[secretpath]
-		if !ok {
-			return "", fmt.Errorf("no value supplied for secret %s", secretpath)
+				err := p.readRune()
+				if err == io.EOF {
+					return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
 		}
-		keys[k] = v
 	}
-	return t.template.Inject(keys)
 }
 
-// Secrets returns a list of paths to secrets that are used in the template.
-func (t secretTemplateV2) Secrets() []string {
-	set := map[string]struct{}{}
-	for _, path := range t.secrets {
-		set[path] = struct{}{}
+// parseSecret parses the contents of a secret tag up to the closing delimiter.
+// parseSecret should be called after the opening delimiter has been read. The next
+// character from the buffer should be the first character of the contents.
+//
+// when parseSecret returns, the next character in the buffer is the first character
+// after the closing delimiter of the secret tag.
+func (p *v2Parser) parseSecret() (node, error) {
+	path := []node{}
+	err := p.readRune()
+	if err == io.EOF {
+		return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+	}
+	if err != nil {
+		return nil, err
+	}
+	for p.next == ' ' {
+		err = p.readRune()
+		if err == io.EOF {
+			return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	result := make([]string, len(set))
+	for {
+		err = p.readRune()
+		if err == io.EOF {
+			return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch p.current {
+		case '$':
+			switch p.next {
+			case '{':
+				err = p.readRune()
+				if err == io.EOF {
+					return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+				variable, err := p.parseVar()
+				if err != nil {
+					return nil, err
+				}
+				path = append(path, variable)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+			default:
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+		case ' ':
+			err := p.forwardToClosing([]rune("}}"))
+			if err != nil {
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+			return secret{
+				path: path,
+			}, nil
+		case '}':
+			switch p.next {
+			case '}':
+				return secret{
+					path: path,
+				}, nil
+			default:
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+		default:
+			if unicode.IsLetter(p.current) || unicode.IsDigit(p.current) || p.current == '_' || p.current == '-' || p.current == '.' || p.current == '/' || p.current == ':' {
+				path = append(path, character(p.current))
+				continue
+			}
+			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+		}
+	}
+}
+
+// forwardToClosing skips all spaces up to the closing delimiter.
+// It returns an error when characters other than spaces occur before the complete
+// closing delimiter occurs.
+func (p *v2Parser) forwardToClosing(delim []rune) error {
+	if len(delim) == 0 {
+		return errors.New("delim should be at least one character long")
+	}
+	for p.next == ' ' {
+		err := p.readRune()
+		if err != nil {
+			return err
+		}
+	}
 	i := 0
-	for path := range set {
-		result[i] = path
+	for {
+		if p.next != delim[i] {
+			return errors.New("expected end delimiter")
+		}
 		i++
+		if i < len(delim) {
+			err := p.readRune()
+			if err != nil {
+				return err
+			}
+		} else {
+			return nil
+		}
 	}
-	return result
+}
+
+// SecretReader fetches a secret by its path.
+type SecretReader interface {
+	ReadSecret(path string) (string, error)
+}
+
+// Evaluate renders a template. It replaces all variable- and secret tags in the template.
+func (t templateV2) Evaluate(vars map[string]string, sr SecretReader) (string, error) {
+	ctx := context{
+		vars:         vars,
+		secretReader: sr,
+	}
+
+	var buffer bytes.Buffer
+	for _, n := range t.nodes {
+		eval, err := n.evaluate(ctx)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(eval)
+	}
+	return buffer.String(), nil
 }

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -1,12 +1,459 @@
-package tpl_test
+package tpl
 
 import (
+	"bytes"
 	"testing"
 
-	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
-	generictpl "github.com/secrethub/secrethub-cli/internals/tpl"
+	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl/fakes"
+
 	"github.com/secrethub/secrethub-go/internals/assert"
 )
+
+func TestParserV2_parse(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected []node
+		err      error
+	}{
+		"no vars, no secrets": {
+			input: "hello world",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"start with var": {
+			input: "${var} world",
+			expected: []node{
+				variable{
+					key: "var",
+				},
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"end with var": {
+			input: "hello ${var}",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				variable{
+					key: "var",
+				},
+			},
+		},
+		"var in middle": {
+			input: "hello ${var} world",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				variable{
+					key: "var",
+				},
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"secret path": {
+			input: "{{path/to/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"secret path in middle": {
+			input: "hello {{path/to/secret}} secret",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+				character(' '),
+				character('s'),
+				character('e'),
+				character('c'),
+				character('r'),
+				character('e'),
+				character('t'),
+			},
+		},
+		"variable in secret path at start": {
+			input: "{{${var}/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						variable{
+							key: "var",
+						},
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"variable in secret path at end": {
+			input: "{{secret${var}}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+						variable{
+							key: "var",
+						},
+					},
+				},
+			},
+		},
+		"variable in secret path at end with space": {
+			input: "{{ secret${var} }}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+						variable{
+							key: "var",
+						},
+					},
+				},
+			},
+		},
+		"variable in secret path in middle": {
+			input: "{{path/to/${var}/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						variable{
+							key: "var",
+						},
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"variable with spaces": {
+			input: "${ var }",
+			expected: []node{
+				variable{
+					key: "var",
+				},
+			},
+		},
+		"secret with spaces": {
+			input: "{{ path/to/secret }}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"{ and } chars used": {
+			input: `{"key": "value"}`,
+			expected: []node{
+				character('{'),
+				character('"'),
+				character('k'),
+				character('e'),
+				character('y'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('"'),
+				character('v'),
+				character('a'),
+				character('l'),
+				character('u'),
+				character('e'),
+				character('"'),
+				character('}'),
+			},
+		},
+		"}} used outside secret tag": {
+			input: `{"a": {"b": "c"}}`,
+			expected: []node{
+				character('{'),
+				character('"'),
+				character('a'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('{'),
+				character('"'),
+				character('b'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('"'),
+				character('c'),
+				character('"'),
+				character('}'),
+				character('}'),
+			},
+		},
+		"$ used": {
+			input: `$12.50`,
+			expected: []node{
+				character('$'),
+				character('1'),
+				character('2'),
+				character('.'),
+				character('5'),
+				character('0'),
+			},
+		},
+		"escaped dollar": {
+			input: `\$`,
+			expected: []node{
+				character('$'),
+			},
+		},
+		"escaped dollar + bracket": {
+			input: `\${var}`,
+			expected: []node{
+				character('$'),
+				character('{'),
+				character('v'),
+				character('a'),
+				character('r'),
+				character('}'),
+			},
+		},
+		"escaped double bracket": {
+			input: `\{{ path }}`,
+			expected: []node{
+				character('{'),
+				character('{'),
+				character(' '),
+				character('p'),
+				character('a'),
+				character('t'),
+				character('h'),
+				character(' '),
+				character('}'),
+				character('}'),
+			},
+		},
+		"escaped backslash": {
+			input: `\\`,
+			expected: []node{
+				character('\\'),
+			},
+		},
+		"escaped opening bracket": {
+			input: `\{`,
+			expected: []node{
+				character('{'),
+			},
+		},
+		"escaped closing bracket": {
+			input: `\}`,
+			expected: []node{
+				character('}'),
+			},
+		},
+		"backslash followed by letter": {
+			input: `\a`,
+			expected: []node{
+				character('\\'),
+				character('a'),
+			},
+		},
+		"$ followed by lowercase letter": {
+			input: "$var",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"$ followed by uppercase letter": {
+			input: "$VAR",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"$ followed by underscore": {
+			input: "$_var",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"illegal variable space": {
+			input: "${ va r }",
+			err:   ErrIllegalVariableCharacter(' ', 1, 6),
+		},
+		"illegal secret space": {
+			input: "{{ secret with space }}",
+			err:   ErrIllegalSecretCharacter(' ', 1, 10),
+		},
+		"illegal variable character": {
+			input: "${ var@var }",
+			err:   ErrIllegalVariableCharacter('@', 1, 7),
+		},
+		"illegal secret character": {
+			input: "{{ a@b }}",
+			err:   ErrIllegalSecretCharacter('@', 1, 5),
+		},
+		"illegal secret character $": {
+			input: "{{ a$b }}",
+			err:   ErrIllegalSecretCharacter('$', 1, 5),
+		},
+		"illegal variable char in secret tag": {
+			input: "{{ path/with/${var@b} }}",
+			err:   ErrIllegalVariableCharacter('@', 1, 19),
+		},
+		"error on new line": {
+			input: "{{ path/to/secret }}\n{{ a%b }}",
+			err:   ErrIllegalSecretCharacter('%', 2, 5),
+		},
+		"secret tag not closed": {
+			input: "{{ path",
+			err: ErrSecretTagNotClosed,
+		},
+		"secret tag not closed after space at end": {
+			input: "{{ path ",
+			err: ErrSecretTagNotClosed,
+		},
+		"secret tag not closed after space at start": {
+			input: "{{ ",
+			err: ErrSecretTagNotClosed,
+		},
+		"secret tag not closed at start of tag": {
+			input: "{{",
+			err: ErrSecretTagNotClosed,
+		},
+		"secret tag not closed after var end": {
+			input: "{{ foo/${var}",
+			err: ErrSecretTagNotClosed,
+		},
+		"secret tag not closed after space after var": {
+			input: "{{ foo/${var} ",
+			err: ErrSecretTagNotClosed,
+		},
+		"variable tag not closed": {
+			input: "${ var",
+			err: ErrVariableTagNotClosed,
+		},
+		"variable tag not closed after space at start": {
+			input: "${ ",
+			err: ErrVariableTagNotClosed,
+		},
+		"variable tag not closed after space at end": {
+			input: "${ var ",
+			err: ErrVariableTagNotClosed,
+		},
+		"variable tag not closed at start of tag": {
+			input: "${",
+			err: ErrVariableTagNotClosed,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			parser := newV2Parser(bytes.NewBufferString(tc.input), 1,1)
+			actual, err := parser.parse()
+
+			assert.Equal(t, actual, tc.expected)
+			assert.Equal(t, err, tc.err)
+		})
+	}
+}
 
 func TestV2(t *testing.T) {
 	cases := map[string]struct {
@@ -14,10 +461,9 @@ func TestV2(t *testing.T) {
 		vars    map[string]string
 		secrets map[string]string
 
-		expected         string
-		parseErr         error
-		injectVarsErr    error
-		injectSecretsErr error
+		expected string
+		parseErr error
+		evalErr  error
 	}{
 		"no secrets": {
 			raw:      "hello world",
@@ -30,7 +476,7 @@ func TestV2(t *testing.T) {
 			},
 			expected: "hello world",
 		},
-		"template var": {
+		"template var in secret": {
 			raw: "hello {{ ${app}/greeting }}",
 			vars: map[string]string{
 				"app": "company/helloworld",
@@ -40,34 +486,45 @@ func TestV2(t *testing.T) {
 			},
 			expected: "hello world",
 		},
+		"end with template var": {
+			raw: "hello {{company/helloworld/${greeting}}}",
+			vars: map[string]string{
+				"greeting": "hello",
+			},
+			secrets: map[string]string{
+				"company/helloworld/hello": "world",
+			},
+			expected: "hello world",
+		},
 		"missing var": {
 			raw:  "hello {{ ${app}/greeting }}",
 			vars: map[string]string{},
 			secrets: map[string]string{
 				"company/helloworld/greeting": "world",
 			},
-			injectVarsErr: generictpl.ErrKeyNotFound("app"),
+			evalErr: ErrTemplateVarNotFound("app"),
+		},
+		"missing var with spaces": {
+			raw:  "hello {{ ${ app }/greeting }}",
+			vars: map[string]string{},
+			secrets: map[string]string{
+				"company/helloworld/greeting": "world",
+			},
+			evalErr: ErrTemplateVarNotFound("app"),
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			parsed, err := tpl.NewV2Parser().Parse(tc.raw)
+			parsed, err := NewV2Parser().Parse(tc.raw, 1, 1)
 			assert.Equal(t, err, tc.parseErr)
 
 			if err != nil {
 				return
 			}
 
-			varsInjected, err := parsed.InjectVars(tc.vars)
-			assert.Equal(t, err, tc.injectVarsErr)
-
-			if err != nil {
-				return
-			}
-
-			actual, err := varsInjected.InjectSecrets(tc.secrets)
-			assert.Equal(t, err, tc.injectSecretsErr)
+			actual, err := parsed.Evaluate(tc.vars, fakes.FakeSecretReader{Secrets: tc.secrets})
+			assert.Equal(t, err, tc.evalErr)
 			assert.Equal(t, actual, tc.expected)
 		})
 	}


### PR DESCRIPTION
This fixes a bug where the closing of a template variable tag
just before the closing of a secret tag returned an error.
Example: {{path/to/secret/${var}}}

The secret templates are now parsed in one go instead of parsing
secret tags first and then parsing the contents of the tag to
look for variables.

The secret template parsing now returns richer error messages, that
include line- and column number where the error occured.

More validation on the contents of the secret- and variable tags
is done while parsing. These errors also include line- and column
number.

dollar signs ($) with a letter, digit or underscore following must
be escaped. This is so that we can add variable support without
brackets later ($var).

$, {, } and \ characters can now be escaped.

Lots of testcases for the parser are added.