### PR TITLE
Rework v2 secret templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/secrethub/secrethub-go v0.20.0
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,9 @@ github.com/secrethub/secrethub-go v0.20.0 h1:NK6G/c1QmmMI7Rwc5nntC66+x0WediVnxea
 github.com/secrethub/secrethub-go v0.20.0/go.mod h1:hfyfrv6v3kPkjOR/E8tEHgO3hxomrN37A59K/nXW0lw=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internals/cli/env_test.go
+++ b/internals/cli/env_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/secrethub/secrethub-go/internals/assert"
 )
 
 func TestSplitVar(t *testing.T) {

--- a/internals/secrethub/inject.go
+++ b/internals/secrethub/inject.go
@@ -16,7 +16,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
 
 	"github.com/secrethub/secrethub-go/internals/errio"
-	"github.com/secrethub/secrethub-go/pkg/secrethub"
 
 	"github.com/docker/go-units"
 )
@@ -124,36 +123,17 @@ func (cmd *InjectCommand) Run() error {
 		return ErrUnknownTemplateVersion(cmd.templateVersion)
 	}
 
-	varTemplate, err := parser.Parse(string(raw))
+	template, err := parser.Parse(string(raw), 1, 1)
 	if err != nil {
 		return errio.Error(err)
 	}
 
-	secretTemplate, err := varTemplate.InjectVars(templateVars)
+	client, err := cmd.newClient()
 	if err != nil {
 		return err
 	}
 
-	secrets := make(map[string]string)
-
-	var client secrethub.Client
-	secretPaths := secretTemplate.Secrets()
-	if len(secretPaths) > 0 {
-		client, err = cmd.newClient()
-		if err != nil {
-			return errio.Error(err)
-		}
-	}
-
-	for _, path := range secretPaths {
-		secret, err := client.Secrets().Versions().GetWithData(path)
-		if err != nil {
-			return errio.Error(err)
-		}
-		secrets[path] = string(secret.Data)
-	}
-
-	injected, err := secretTemplate.InjectSecrets(secrets)
+	injected, err := template.Evaluate(templateVars, newSecretReader(client))
 	if err != nil {
 		return errio.Error(err)
 	}

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -131,7 +131,7 @@ func (cmd *RunCommand) Run() error {
 	}
 
 	if cmd.template != "" {
-		envFile, err := NewEnvFile(cmd.template, templateVars)
+		envFile, err := ReadEnvFile(cmd.template, templateVars)
 		if err != nil {
 			return err
 		}
@@ -350,8 +350,8 @@ func (t envTemplate) Secrets() []string {
 	return []string{}
 }
 
-// NewEnvFile returns an new environment from a file.
-func NewEnvFile(filepath string, vars map[string]string) (EnvFile, error) {
+// ReadEnvFile reads and parses a .env file.
+func ReadEnvFile(filepath string, vars map[string]string) (EnvFile, error) {
 	content, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return EnvFile{}, ErrCannotReadFile(filepath, err)

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -437,7 +437,7 @@ type envvar struct {
 func parseEnvironment(r io.Reader) ([]envvar, tpl.Parser, error) {
 	parser := tpl.NewV2Parser()
 	var ymlReader bytes.Buffer
-	env, err := parseEnv(io.TeeReader(r, &ymlReader))
+	env, err := parseDotEnv(io.TeeReader(r, &ymlReader))
 	if err != nil {
 		var ymlErr error
 		parser = tpl.NewV1Parser()
@@ -449,7 +449,8 @@ func parseEnvironment(r io.Reader) ([]envvar, tpl.Parser, error) {
 	return env, parser, nil
 }
 
-func parseEnv(r io.Reader) ([]envvar, error) {
+// parseDotEnv parses key-value pairs in the .env syntax (key=value).
+func parseDotEnv(r io.Reader) ([]envvar, error) {
 	vars := map[string]envvar{}
 	scanner := bufio.NewScanner(r)
 

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -130,8 +130,13 @@ func (cmd *RunCommand) Run() error {
 		}
 	}
 
+	client, err := cmd.newClient()
+	if err != nil {
+		return errio.Error(err)
+	}
+
 	if cmd.template != "" {
-		tplSource, err := NewEnvFile(cmd.template, templateVars)
+		tplSource, err := NewEnvFile(cmd.template, templateVars, newSecretReader(client))
 		if err != nil {
 			return err
 		}
@@ -154,11 +159,6 @@ func (cmd *RunCommand) Run() error {
 		for _, path := range source.Secrets() {
 			secrets[path] = ""
 		}
-	}
-
-	client, err := cmd.newClient()
-	if err != nil {
-		return errio.Error(err)
 	}
 
 	for path := range secrets {
@@ -325,7 +325,9 @@ type EnvSource interface {
 }
 
 type envTemplate struct {
-	envVars map[string]tpl.SecretTemplate
+	envVars      map[string]tpl.Template
+	templateVars map[string]string
+	secretReader tpl.SecretReader
 }
 
 // Env injects the given secrets in the environment values and returns
@@ -333,7 +335,7 @@ type envTemplate struct {
 func (t envTemplate) Env(secrets map[string]string) (map[string]string, error) {
 	result := make(map[string]string)
 	for key, template := range t.envVars {
-		value, err := template.InjectSecrets(secrets)
+		value, err := template.Evaluate(t.templateVars, t.secretReader)
 		if err != nil {
 			return nil, err
 		}
@@ -342,31 +344,19 @@ func (t envTemplate) Env(secrets map[string]string) (map[string]string, error) {
 	return result, nil
 }
 
-// Secrets returns a list of paths to secrets that are used in the environment.
+// Secrets implements the EnvSource.Secrets function.
+// The envTemplate fetches its secrets using a tpl.SecretReader.
 func (t envTemplate) Secrets() []string {
-	set := map[string]struct{}{}
-	for _, template := range t.envVars {
-		for _, secretpath := range template.Secrets() {
-			set[secretpath] = struct{}{}
-		}
-	}
-
-	result := make([]string, len(set))
-	i := 0
-	for secretpath := range set {
-		result[i] = secretpath
-		i++
-	}
-	return result
+	return []string{}
 }
 
 // NewEnvFile returns an new environment from a file.
-func NewEnvFile(filepath string, vars map[string]string) (EnvFile, error) {
+func NewEnvFile(filepath string, vars map[string]string, sr tpl.SecretReader) (EnvFile, error) {
 	content, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return EnvFile{}, ErrCannotReadFile(filepath, err)
 	}
-	env, err := NewEnv(string(content), vars)
+	env, err := NewEnv(string(content), vars, sr)
 	if err != nil {
 		return EnvFile{}, err
 	}
@@ -398,33 +388,30 @@ func (e EnvFile) Secrets() []string {
 
 // NewEnv loads an environment of key-value pairs from a string.
 // The format of the string can be `key: value` or `key=value` pairs.
-func NewEnv(raw string, vars map[string]string) (EnvSource, error) {
+func NewEnv(raw string, vars map[string]string, sr tpl.SecretReader) (EnvSource, error) {
 	env, parser, err := parseEnvironment(raw)
 	if err != nil {
 		return nil, err
 	}
 
-	secretTemplates := make(map[string]tpl.SecretTemplate, len(env))
+	secretTemplates := make(map[string]tpl.Template, len(env))
 	for _, envvar := range env {
 		err = validation.ValidateEnvarName(envvar.key)
 		if err != nil {
 			return nil, templateError(envvar, err)
 		}
 
-		template, err := parser.Parse(envvar.value)
+		template, err := parser.Parse(envvar.value, envvar.lineNumber, envvar.columnNumber)
 		if err != nil {
-			return nil, templateError(envvar, err)
+			return nil, err
 		}
-
-		injected, err := template.InjectVars(vars)
-		if err != nil {
-			return nil, templateError(envvar, err)
-		}
-		secretTemplates[envvar.key] = injected
+		secretTemplates[envvar.key] = template
 	}
 
 	return envTemplate{
-		envVars: secretTemplates,
+		envVars:      secretTemplates,
+		templateVars: vars,
+		secretReader: sr,
 	}, nil
 }
 
@@ -436,9 +423,10 @@ func templateError(envvar envvar, err error) error {
 }
 
 type envvar struct {
-	key        string
-	value      string
-	lineNumber int
+	key          string
+	value        string
+	lineNumber   int
+	columnNumber int
 }
 
 // parseEnvironment parses envvars from a string.
@@ -475,9 +463,10 @@ func parseEnv(raw string) ([]envvar, error) {
 		value := strings.TrimLeft(parts[1], " ")
 
 		vars[key] = envvar{
-			key:        key,
-			value:      value,
-			lineNumber: i,
+			key:          key,
+			value:        value,
+			lineNumber:   i,
+			columnNumber: len(parts[0]) + 1 + len(parts[1]) - len(value) + 1, // the length of the key (including extra spaces) + the length of the = char + the length of the spaces before the value + 1 for the current char
 		}
 		i++
 	}

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -136,11 +136,11 @@ func (cmd *RunCommand) Run() error {
 	}
 
 	if cmd.template != "" {
-		tplSource, err := NewEnvFile(cmd.template, templateVars, newSecretReader(client))
+		envFile, err := NewEnvFile(cmd.template, templateVars, newSecretReader(client))
 		if err != nil {
 			return err
 		}
-		envSources = append(envSources, tplSource)
+		envSources = append(envSources, envFile)
 	}
 
 	envDir := filepath.Join(secretspec.SecretEnvPath, cmd.env)

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -70,7 +70,7 @@ func TestParseDotEnv(t *testing.T) {
 				},
 			},
 		},
-		"success with multiple spaces": {
+		"success with multiple spaces before key": {
 			raw: "key    = value",
 			expected: []envvar{
 				{
@@ -78,6 +78,17 @@ func TestParseDotEnv(t *testing.T) {
 					value:        "value",
 					lineNumber:   1,
 					columnNumber: 10,
+				},
+			},
+		},
+		"success with multiple spaces before value": {
+			raw: "key =  value",
+			expected: []envvar{
+				{
+					key:          "key",
+					value:        "value",
+					lineNumber:   1,
+					columnNumber: 8,
 				},
 			},
 		},

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -70,7 +70,7 @@ func TestParseDotEnv(t *testing.T) {
 				},
 			},
 		},
-		"success with multiple spaces before key": {
+		"success with multiple spaces after key": {
 			raw: "key    = value",
 			expected: []envvar{
 				{

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -220,11 +220,11 @@ func TestNewEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			env, err := NewEnv(tc.raw, tc.templateVars, fakes.FakeSecretReader{Secrets: tc.replacements})
+			env, err := NewEnv(tc.raw, tc.templateVars)
 			if err != nil {
 				assert.Equal(t, err, tc.err)
 			} else {
-				actual, err := env.Env(map[string]string{})
+				actual, err := env.Env(map[string]string{}, fakes.FakeSecretReader{Secrets: tc.replacements})
 				assert.Equal(t, err, tc.err)
 
 				assert.Equal(t, actual, tc.expected)

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -36,7 +36,7 @@ isEncountered:
 	}
 }
 
-func TestParseEnv(t *testing.T) {
+func TestParseDotEnv(t *testing.T) {
 	cases := map[string]struct {
 		raw      string
 		expected []envvar
@@ -100,7 +100,7 @@ func TestParseEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual, err := parseEnv(strings.NewReader(tc.raw))
+			actual, err := parseDotEnv(strings.NewReader(tc.raw))
 
 			elemEqual(t, actual, tc.expected)
 			assert.Equal(t, err, tc.err)

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -226,7 +226,7 @@ func TestNewEnv(t *testing.T) {
 		},
 		"secret template error second line": {
 			raw: "foo=bar\nbar={{ error@secretpath }}",
-			err: tpl.ErrIllegalSecretCharacter('@', 2, 13),
+			err: tpl.ErrIllegalSecretCharacter(2, 13, '@'),
 		},
 	}
 

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
@@ -99,7 +100,7 @@ func TestParseEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual, err := parseEnv(tc.raw)
+			actual, err := parseEnv(strings.NewReader(tc.raw))
 
 			elemEqual(t, actual, tc.expected)
 			assert.Equal(t, err, tc.err)
@@ -151,7 +152,7 @@ func TestParseYML(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			actual, err := parseYML(tc.raw)
+			actual, err := parseYML(strings.NewReader(tc.raw))
 
 			elemEqual(t, actual, tc.expected)
 			assert.Equal(t, err, tc.err)
@@ -220,7 +221,7 @@ func TestNewEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			env, err := NewEnv(tc.raw, tc.templateVars)
+			env, err := NewEnv(strings.NewReader(tc.raw), tc.templateVars)
 			if err != nil {
 				assert.Equal(t, err, tc.err)
 			} else {

--- a/internals/secrethub/secret_reader.go
+++ b/internals/secrethub/secret_reader.go
@@ -1,0 +1,19 @@
+package secrethub
+
+import "github.com/secrethub/secrethub-go/pkg/secrethub"
+
+type secretReader struct {
+	client secrethub.Client
+}
+
+func newSecretReader(client secrethub.Client) secretReader {
+	return secretReader{client: client}
+}
+
+func (sr secretReader) ReadSecret(path string) (string, error) {
+	secret, err := sr.client.Secrets().Versions().GetWithData(path)
+	if err != nil {
+		return "", err
+	}
+	return string(secret.Data), nil
+}

--- a/internals/secrethub/secret_reader.go
+++ b/internals/secrethub/secret_reader.go
@@ -6,10 +6,12 @@ type secretReader struct {
 	client secrethub.Client
 }
 
+// newSecretReader wraps a client to implement tpl.SecretReader.
 func newSecretReader(client secrethub.Client) secretReader {
 	return secretReader{client: client}
 }
 
+// ReadSecret reads the secret using the provided client.
 func (sr secretReader) ReadSecret(path string) (string, error) {
 	secret, err := sr.client.Secrets().Versions().GetWithData(path)
 	if err != nil {

--- a/internals/secrethub/tpl/errors.go
+++ b/internals/secrethub/tpl/errors.go
@@ -40,7 +40,7 @@ func ErrUnexpectedCharacter(lineNo, colNo int, actual, expected rune) error {
 		lineNo: lineNo,
 		colNo:  colNo,
 		code:   "unexpected character",
-		msg:    fmt.Sprintf("unexpected '%c' expected '%c'", actual, expected),
+		msg:    fmt.Sprintf("unexpected '%c', expected '%c'", actual, expected),
 	}
 }
 

--- a/internals/secrethub/tpl/errors.go
+++ b/internals/secrethub/tpl/errors.go
@@ -31,6 +31,19 @@ func ErrUnexpectedDollar(lineNo, colNo int) error {
 	}
 }
 
+// ErrUnexpectedCharacter is returned when expecting a specific character, for example
+// the first character of a closing delimiter after a space occurred in a tag, or
+// the second character of a closing delimiter after the first character of the closing
+// delimiter.
+func ErrUnexpectedCharacter(lineNo, colNo int, actual, expected rune) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "unexpected character",
+		msg:    fmt.Sprintf("unexpected '%c' expected '%c'", actual, expected),
+	}
+}
+
 // ErrIllegalVariableCharacter is returned when a variable tag contains a character that is not allowed.
 func ErrIllegalVariableCharacter(lineNo, colNo int, char rune) error {
 	return templateSyntaxError{

--- a/internals/secrethub/tpl/errors.go
+++ b/internals/secrethub/tpl/errors.go
@@ -37,7 +37,7 @@ func ErrIllegalVariableCharacter(lineNo, colNo int, char rune) error {
 		lineNo: lineNo,
 		colNo:  colNo,
 		code:   "illegal_variable_character",
-		msg:    fmt.Sprintf("Illegal character '%c'. Variable names can only contain letters, digits and underscores.", char),
+		msg:    fmt.Sprintf("illegal character '%c'. Variable names can only contain letters, digits and underscores.", char),
 	}
 }
 
@@ -47,7 +47,7 @@ func ErrIllegalSecretCharacter(lineNo, colNo int, char rune) error {
 		lineNo: lineNo,
 		colNo:  colNo,
 		code:   "illegal_secret_character",
-		msg:    fmt.Sprintf("Illegal character '%c'. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.", char),
+		msg:    fmt.Sprintf("illegal character '%c'. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.", char),
 	}
 }
 
@@ -57,7 +57,7 @@ func ErrSecretTagNotClosed(lineNo, colNo int) error {
 		lineNo: lineNo,
 		colNo:  colNo,
 		code:   "secret_tag_not_closed",
-		msg:    "Expected the closing of a secret tag `}}`, but reached the end of the template.",
+		msg:    "expected the closing of a secret tag `}}`, but reached the end of the template.",
 	}
 }
 
@@ -67,6 +67,6 @@ func ErrVariableTagNotClosed(lineNo, colNo int) error {
 		lineNo: lineNo,
 		colNo:  colNo,
 		code:   "variable_tag_not_closed",
-		msg:    "Expected the closing of a variable tag `}`, but reached the end of the template.",
+		msg:    "expected the closing of a variable tag `}`, but reached the end of the template.",
 	}
 }

--- a/internals/secrethub/tpl/errors.go
+++ b/internals/secrethub/tpl/errors.go
@@ -1,0 +1,72 @@
+package tpl
+
+import (
+	"fmt"
+)
+
+// Evaluate errors
+var (
+	ErrTemplateVarNotFound = tplError.Code("template_var_not_found").ErrorPref("no value was supplied for template variable '%s'")
+)
+
+// Parse errors
+type templateSyntaxError struct {
+	lineNo int
+	colNo  int
+	code   string
+	msg    string
+}
+
+func (err templateSyntaxError) Error() string {
+	return tplError.Code(err.code).Errorf("template syntax error at %d:%d: %s", err.lineNo, err.colNo, err.msg).Error()
+}
+
+// ErrUnexpectedDollar is returned when an unescaped dollar sign is followed by a letter or underscore.
+func ErrUnexpectedDollar(lineNo, colNo int) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "unexpected character",
+		msg:    "unexpected '$'. Use '\\$' if you want to output a dollar sign.",
+	}
+}
+
+// ErrIllegalVariableCharacter is returned when a variable tag contains a character that is not allowed.
+func ErrIllegalVariableCharacter(lineNo, colNo int, char rune) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "illegal_variable_character",
+		msg:    fmt.Sprintf("Illegal character '%c'. Variable names can only contain letters, digits and underscores.", char),
+	}
+}
+
+// ErrIllegalSecretCharacter is returned when a secret tag contains a character that is not allowed.
+func ErrIllegalSecretCharacter(lineNo, colNo int, char rune) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "illegal_secret_character",
+		msg:    fmt.Sprintf("Illegal character '%c'. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.", char),
+	}
+}
+
+// ErrSecretTagNotClosed is returned when a secret tag is opened, but never closed.
+func ErrSecretTagNotClosed(lineNo, colNo int) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "secret_tag_not_closed",
+		msg:    "Expected the closing of a secret tag `}}`, but reached the end of the template.",
+	}
+}
+
+// ErrVariableTagNotClosed is returned when a variable tag is opened, but never closed.
+func ErrVariableTagNotClosed(lineNo, colNo int) error {
+	return templateSyntaxError{
+		lineNo: lineNo,
+		colNo:  colNo,
+		code:   "variable_tag_not_closed",
+		msg:    "Expected the closing of a variable tag `}`, but reached the end of the template.",
+	}
+}

--- a/internals/secrethub/tpl/fakes/secret_reader.go
+++ b/internals/secrethub/tpl/fakes/secret_reader.go
@@ -1,0 +1,17 @@
+package fakes
+
+import "errors"
+
+// FakeSecretReader implements tpl.SecretReader.
+type FakeSecretReader struct {
+	Secrets map[string]string
+}
+
+// ReadSecret implements tpl.SecretReader.ReadSecret.
+func (fsr FakeSecretReader) ReadSecret(path string) (string, error) {
+	secret, ok := fsr.Secrets[path]
+	if ok {
+		return secret, nil
+	}
+	return "", errors.New("secret not found")
+}

--- a/internals/secrethub/tpl/internal/token/token.go
+++ b/internals/secrethub/tpl/internal/token/token.go
@@ -7,16 +7,15 @@ var (
 	RBracket  = '}'
 	Backslash = '\\'
 
-	tokens = map[rune]struct{}{
-		Dollar:    {},
-		LBracket:  {},
-		RBracket:  {},
-		Backslash: {},
-	}
+	tokens = []rune{Dollar, LBracket, RBracket, Backslash}
 )
 
 // IsToken returns whether the given rune is a token.
 func IsToken(ch rune) bool {
-	_, isToken := tokens[ch]
-	return isToken
+	for _, token := range tokens {
+		if ch == token {
+			return true
+		}
+	}
+	return false
 }

--- a/internals/secrethub/tpl/internal/token/token.go
+++ b/internals/secrethub/tpl/internal/token/token.go
@@ -15,26 +15,6 @@ var (
 	}
 )
 
-// IsDollar returns whether the given rune is the dollar token.
-func IsDollar(ch rune) bool {
-	return ch == Dollar
-}
-
-// IsLBracket returns whether the given rune is the left bracket token.
-func IsLBracket(ch rune) bool {
-	return ch == LBracket
-}
-
-// IsRBracket returns whether the given rune is the right bracket token.
-func IsRBracket(ch rune) bool {
-	return ch == RBracket
-}
-
-// IsBackslash returns whether the given rune is the backlash token.
-func IsBackslash(ch rune) bool {
-	return ch == Backslash
-}
-
 // IsToken returns whether the given rune is a token.
 func IsToken(ch rune) bool {
 	_, isToken := tokens[ch]

--- a/internals/secrethub/tpl/internal/token/token.go
+++ b/internals/secrethub/tpl/internal/token/token.go
@@ -1,0 +1,42 @@
+package token
+
+// Tokens
+var (
+	Dollar    = '$'
+	LBracket  = '{'
+	RBracket  = '}'
+	Backslash = '\\'
+
+	tokens = map[rune]struct{}{
+		Dollar:    {},
+		LBracket:  {},
+		RBracket:  {},
+		Backslash: {},
+	}
+)
+
+// IsDollar returns whether the given rune is the dollar token.
+func IsDollar(ch rune) bool {
+	return ch == Dollar
+}
+
+// IsLBracket returns whether the given rune is the left bracket token.
+func IsLBracket(ch rune) bool {
+	return ch == LBracket
+}
+
+// IsRBracket returns whether the given rune is the right bracket token.
+func IsRBracket(ch rune) bool {
+	return ch == RBracket
+}
+
+// IsBackslash returns whether the given rune is the backlash token.
+func IsBackslash(ch rune) bool {
+	return ch == Backslash
+}
+
+// IsToken returns whether the given rune is a token.
+func IsToken(ch rune) bool {
+	_, isToken := tokens[ch]
+	return isToken
+}

--- a/internals/secrethub/tpl/template.go
+++ b/internals/secrethub/tpl/template.go
@@ -1,21 +1,20 @@
 package tpl
 
+import "github.com/secrethub/secrethub-go/internals/errio"
+
+// Errors
+var (
+	tplError = errio.Namespace("template")
+)
+
 // Parser parses a raw string to a template.
 type Parser interface {
-	Parse(raw string) (VarTemplate, error)
+	Parse(raw string, column, line int) (Template, error)
 }
 
-// VarTemplate is a template containing variables. Once variables are injected,
-// secret paths can be retrieved and injected as well to retrieve the resulting string.
-type VarTemplate interface {
-	InjectVars(vars map[string]string) (SecretTemplate, error)
-}
-
-// SecretTemplate is a template containing secret paths. The plaintext values corresponding
-// to these paths can be injected to retrieve the resulting string.
-type SecretTemplate interface {
-	InjectSecrets(secrets map[string]string) (string, error)
-	Secrets() []string
+// Template contains secret and variable references. It can be evaluated to resolve to a string.
+type Template interface {
+	Evaluate(vars map[string]string, sr SecretReader) (string, error)
 }
 
 // NewParser returns a parser for the latest template syntax.

--- a/internals/secrethub/tpl/v1.go
+++ b/internals/secrethub/tpl/v1.go
@@ -2,12 +2,11 @@ package tpl
 
 import (
 	"github.com/secrethub/secrethub-cli/internals/tpl"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // Errors
 var (
-	ErrTemplateVarsNotSupported = errio.Namespace("template").Code("template_vars_not_supported").Error("the v1 template syntax does not support template variables")
+	ErrTemplateVarsNotSupported = tplError.Code("template_vars_not_supported").Error("the v1 template syntax does not support template variables")
 )
 
 // NewV1Parser returns a parser for the v1 template syntax.
@@ -28,7 +27,7 @@ type parserV1 struct{}
 
 // Parse parses a secret template from a raw string.
 // See tpl.Template for the format of the template.
-func (p parserV1) Parse(raw string) (VarTemplate, error) {
+func (p parserV1) Parse(raw string, _, _ int) (Template, error) {
 	t, err := tpl.NewParser("${", "}").Parse(raw)
 	if err != nil {
 		return nil, err
@@ -39,28 +38,22 @@ func (p parserV1) Parse(raw string) (VarTemplate, error) {
 	}, nil
 }
 
-// secretTemplateV1 is a template that only contains secret keys.
-type secretTemplateV1 struct {
-	template tpl.Template
-}
-
 // InjectVars takes a map of template variables with their corresponding values. It replaces
 // the template variables with their values in the template.
-func (t templateV1) InjectVars(vars map[string]string) (SecretTemplate, error) {
+func (t templateV1) Evaluate(vars map[string]string, sr SecretReader) (string, error) {
 	if len(vars) > 0 {
-		return nil, ErrTemplateVarsNotSupported
+		return "", ErrTemplateVarsNotSupported
 	}
 
-	return secretTemplateV1(t), nil
-}
+	keys := t.template.Keys()
+	secrets := make(map[string]string, len(keys))
+	for _, path := range keys {
+		secret, err := sr.ReadSecret(path)
+		if err != nil {
+			return "", err
+		}
+		secrets[path] = secret
+	}
 
-// InjectSecrets takes a map of secret paths with their corresponding values. It replaces
-// the secret paths with the corresponding values in the template.
-func (t secretTemplateV1) InjectSecrets(secrets map[string]string) (string, error) {
 	return t.template.Inject(secrets)
-}
-
-// Secrets returns a list of paths to secrets that are used in the template.
-func (t secretTemplateV1) Secrets() []string {
-	return t.template.Keys()
 }

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -247,18 +247,19 @@ func (p *v2Parser) parse() ([]node, error) {
 func (p *v2Parser) parseVar() (node, error) {
 	var buffer bytes.Buffer
 
-	err := p.readRune()
-	if err == io.EOF {
-		return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+	checkError := func(err error) error {
+		if err == io.EOF {
+			return ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		return err
 	}
+
+	err := checkError(p.readRune())
 	if err != nil {
 		return nil, err
 	}
 
-	err = p.skipWhiteSpace()
-	if err == io.EOF {
-		return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
-	}
+	err = checkError(p.skipWhiteSpace())
 	if err != nil {
 		return nil, err
 	}
@@ -271,10 +272,7 @@ func (p *v2Parser) parseVar() (node, error) {
 		}
 
 		if p.isAllowedWhiteSpace(p.next) {
-			err := p.skipWhiteSpace()
-			if err == io.EOF {
-				return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
-			}
+			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
 			}
@@ -291,10 +289,7 @@ func (p *v2Parser) parseVar() (node, error) {
 		if p.isVariableRune(p.next) {
 			buffer.WriteRune(p.next)
 
-			err := p.readRune()
-			if err == io.EOF {
-				return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
-			}
+			err := checkError(p.readRune())
 			if err != nil {
 				return nil, err
 			}
@@ -315,27 +310,25 @@ func (p *v2Parser) parseVar() (node, error) {
 func (p *v2Parser) parseSecret() (node, error) {
 	path := []node{}
 
-	err := p.readRune()
-	if err == io.EOF {
-		return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+	checkError := func(err error) error {
+		if err == io.EOF {
+			return ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		return err
 	}
+
+	err := checkError(p.readRune())
 	if err != nil {
 		return nil, err
 	}
 
-	err = p.skipWhiteSpace()
-	if err == io.EOF {
-		return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
-	}
+	err = checkError(p.skipWhiteSpace())
 	if err != nil {
 		return nil, err
 	}
 
 	for {
-		err = p.readRune()
-		if err == io.EOF {
-			return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
-		}
+		err = checkError(p.readRune())
 		if err != nil {
 			return nil, err
 		}
@@ -349,10 +342,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 
 				path = append(path, variable)
 
-				err = p.readRune()
-				if err == io.EOF {
-					return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
-				}
+				err = checkError(p.readRune())
 				if err != nil {
 					return nil, err
 				}
@@ -362,10 +352,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 		}
 		if p.isAllowedWhiteSpace(p.current) {
-			err := p.skipWhiteSpace()
-			if err == io.EOF {
-				return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
-			}
+			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
 			}
@@ -374,10 +361,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 			}
 
-			err = p.readRune()
-			if err == io.EOF {
-				return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
-			}
+			err = checkError(p.readRune())
 			if err != nil {
 				return nil, err
 			}

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -265,7 +265,7 @@ func (p *v2Parser) parseVar() (node, error) {
 	}
 
 	for {
-		if token.IsRBracket(p.next) {
+		if p.next == token.RBracket {
 			return variable{
 				key: buffer.String(),
 			}, nil
@@ -277,7 +277,7 @@ func (p *v2Parser) parseVar() (node, error) {
 				return nil, err
 			}
 
-			if token.IsRBracket(p.next) {
+			if p.next == token.RBracket {
 				return variable{
 					key: buffer.String(),
 				}, nil
@@ -333,8 +333,8 @@ func (p *v2Parser) parseSecret() (node, error) {
 			return nil, err
 		}
 
-		if token.IsDollar(p.current) {
-			if token.IsLBracket(p.next) {
+		if p.current == token.Dollar {
+			if p.next == token.LBracket {
 				variable, err := p.parseVar()
 				if err != nil {
 					return nil, err
@@ -357,7 +357,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				return nil, err
 			}
 
-			if !token.IsRBracket(p.next) {
+			if p.next != token.RBracket {
 				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 			}
 
@@ -366,7 +366,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				return nil, err
 			}
 
-			if !token.IsRBracket(p.next) {
+			if p.next != token.RBracket {
 				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo-1, ' ')
 			}
 
@@ -375,8 +375,8 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}, nil
 		}
 
-		if token.IsRBracket(p.current) {
-			if token.IsRBracket(p.next) {
+		if p.current == token.RBracket {
+			if p.next == token.RBracket {
 				return secret{
 					path: path,
 				}, nil

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -97,21 +97,18 @@ type parserV2 struct{}
 
 // Parse parses a secret template from a raw string.
 //
-// A secret template can contain references to secrets in secret tags.
-// A secret tag is enclosed in double brackets: `{{ <path> }}`.
-//
-// A secret template can contain references to variables in variable tags.
-// A variable tag is enclosed in `${ <variable key> }`.
-//
-// Secret tags can contain variable tags:
-// `{{ path/with/${var}/to/secret }}`
-//
-// Extra spaces can be added just after the opening delimiter and just before the closing delimiter of a tag:
-// {{ path/to/secret }} has the same output as {{path/to/secret}} has.
-//
-// Variable tags cannot contain secret tags.
-// Secret tags cannot contain secret tags (they cannot be nested).
-// Variable tags cannot contain variable tags (they cannot be nested).
+// Syntax rules:
+// - A secret template can contain references to secrets in secret tags. A
+//   secret tag is enclosed in double brackets: `{{ path/to/secret }}`.
+// - A secret template can contain references to variables in variable tags. A
+//   variable tag is enclosed between ${ and }: `${ variable }`.
+// - Extra spaces can be added just after the opening delimiter and just before the
+//   closing delimiter of a tag: {{ path/to/secret }} has the same output as
+//   {{path/to/secret}} has.
+// - Secret tags can also contain variable tags: `{{ path/with/${var}/to/secret }}`
+// - Variable tags cannot contain secret tags.
+// - Secret tags cannot contain secret tags (they cannot be nested).
+// - Variable tags cannot contain variable tags (they cannot be nested).
 func (p parserV2) Parse(raw string, line, column int) (Template, error) {
 	parser := newV2Parser(bytes.NewBufferString(raw), line, column)
 

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -1,9 +1,22 @@
 package tpl
 
 import (
-	"fmt"
+	"bytes"
+	"errors"
+	"io"
+	"unicode"
+)
 
-	"github.com/secrethub/secrethub-cli/internals/tpl"
+// Errors
+var (
+	ErrTemplateVarNotFound      = tplError.Code("template_var_not_found").ErrorPref("no value was supplied for template variable '%s'")
+	ErrUnexpectedDollar         = tplError.Code("unexpected_character").ErrorPref("unexpected '$' at line %d column %d. Use '\\$' if you want to output a dollar sign.")
+	ErrIllegalVariableCharacter = tplError.Code("illegal_variable_character").ErrorPref("Illegal character '%s' at line %d column %d. Variable names can only contain letters, digits and underscores.")
+	ErrIllegalSecretCharacter   = tplError.Code("illegal_secret_character").ErrorPref("Illegel character '%s' at line %d column %d. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.")
+	ErrSecretTagNotClosed       = tplError.Code("secret_tag_not_closed").ErrorPref("Expected the closing of a secret tag `}}` at line %d column %d, but reached the end of the template.")
+	ErrVariableTagNotClosed     = tplError.Code("variable_tag_not_closed").ErrorPref("Expected the closing of a variable tag `}` at line %d column %d, but reached the end of the template.")
+
+	specialChars = []rune{'$', '{', '}', '\\'}
 )
 
 // NewV2Parser returns a parser for the v2 template syntax.
@@ -24,95 +37,418 @@ func NewV2Parser() Parser {
 	return parserV2{}
 }
 
+type context struct {
+	vars         map[string]string
+	secretReader SecretReader
+}
+
+func (ctx context) secret(path string) (string, error) {
+	return ctx.secretReader.ReadSecret(path)
+}
+
+type node interface {
+	evaluate(ctx context) (string, error)
+}
+
+type secret struct {
+	path []node
+}
+
+func (s secret) evaluate(ctx context) (string, error) {
+	var buffer bytes.Buffer
+	for _, p := range s.path {
+		eval, err := p.evaluate(ctx)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(eval)
+	}
+	return ctx.secret(buffer.String())
+}
+
+type variable struct {
+	key string
+}
+
+func (v variable) evaluate(ctx context) (string, error) {
+	res, ok := ctx.vars[v.key]
+	if !ok {
+		return "", ErrTemplateVarNotFound(v.key)
+	}
+	return res, nil
+}
+
+type character rune
+
+func (c character) evaluate(ctx context) (string, error) {
+	return string(c), nil
+}
+
 type templateV2 struct {
-	template tpl.Template
-	// secrets is a map of template keys (can contain variables) and the corresponding
-	// template variable templates.
-	secrets map[string]tpl.Template
+	nodes []node
 }
 
 type parserV2 struct{}
 
 // Parse parses a secret template from a raw string.
-// See tpl.Template for the format of the template.
-func (p parserV2) Parse(raw string) (VarTemplate, error) {
-	t, err := tpl.NewParser("{{", "}}").Parse(raw)
+//
+// A secret template can contain references to secrets in secret tags.
+// A secret tag is enclosed in double brackets: `{{ <path> }}`.
+//
+// A secret template can contain references to variables in variable tags.
+// A variable tag is enclosed in `${ <variable key> }`.
+//
+// Secret tags can contain variable tags:
+// `{{ path/with/${var}/to/secret }}`
+//
+// Extra spaces can be added just after the opening delimiter and just before the closing delimiter of a tag:
+// {{ path/to/secret }} has the same output as {{path/to/secret}} has.
+//
+// Variable tags cannot contain secret tags.
+// Secret tags cannot contain secret tags (they cannot be nested).
+// Variable tags cannot contain variable tags (they cannot be nested).
+func (p parserV2) Parse(raw string, line, column int) (Template, error) {
+	parser := newV2Parser(bytes.NewBufferString(raw), line, column)
+	nodes, err := parser.parse()
+	if err != nil {
+		return nil, err
+	}
+	return templateV2{
+		nodes: nodes,
+	}, nil
+}
+
+func newV2Parser(buf *bytes.Buffer, line, column int) v2Parser {
+	return v2Parser{
+		buf:    buf,
+		lineNo: line,
+		// The column number indicates the index (starting at 1) of the current rune.
+		// We subtract 2 of the given value. One bacause we have not read the current rune yet and
+		// one more because we are reading the next rune in advance (which we don't want to count).
+		columnNo: column - 2,
+	}
+}
+
+type v2Parser struct {
+	buf      *bytes.Buffer
+	lineNo   int
+	columnNo int
+
+	current rune
+	next    rune
+}
+
+// readRune reads the next rune from the raw template.
+func (p *v2Parser) readRune() error {
+	p.current = p.next
+	if p.current == '\n' {
+		p.lineNo++
+		p.columnNo = 0
+	} else {
+		p.columnNo++
+	}
+
+	var err error
+	p.next, _, err = p.buf.ReadRune()
+	return err
+}
+
+func (p *v2Parser) parse() ([]node, error) {
+	res := []node{}
+	err := p.readRune()
+	if err == io.EOF {
+		return res, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	keys := t.Keys()
-
-	secrets := make(map[string]tpl.Template, len(keys))
-
-	templateVarParser := tpl.NewParser("${", "}")
-	for _, k := range keys {
-		parsed, err := templateVarParser.Parse(k)
+	for {
+		err := p.readRune()
+		if err == io.EOF {
+			return append(res, character(p.current)), nil
+		}
 		if err != nil {
 			return nil, err
 		}
-		secrets[k] = parsed
+
+		switch p.current {
+		case '$':
+			switch p.next {
+			case '{':
+				err = p.readRune()
+				if err == io.EOF {
+					return res, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				variable, err := p.parseVar()
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, variable)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				continue
+			default:
+				// We don't allow dollars before letters and underscores now,
+				// as we might want to use these for $var support (without brackets) later.
+				if unicode.IsLetter(p.next) || p.next == '_' {
+					return nil, ErrUnexpectedDollar(p.lineNo, p.columnNo)
+				}
+				res = append(res, character(p.current))
+				continue
+			}
+		case '{':
+			switch p.next {
+			case '{':
+				secret, err := p.parseSecret()
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, secret)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+				continue
+			default:
+				res = append(res, character(p.current))
+				continue
+			}
+		case '\\':
+			isSpecialChar := false
+			for _, specialChar := range specialChars {
+				if p.next == specialChar {
+					isSpecialChar = true
+					break
+				}
+			}
+			if isSpecialChar {
+				res = append(res, character(p.next))
+				err = p.readRune()
+				if err == io.EOF {
+					return res, nil
+				}
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				res = append(res, character(p.current))
+			}
+			continue
+		default:
+			res = append(res, character(p.current))
+			continue
+		}
 	}
-
-	return templateV2{
-		template: t,
-		secrets:  secrets,
-	}, nil
 }
 
-// secretTemplateV2 is a template that only contains secret keys. Template variables
-// are already replaced.
-type secretTemplateV2 struct {
-	template tpl.Template
-	// secrets is a map of template keys (can contain variables) and the corresponding
-	// secret paths (with variables replaced by their values).
-	secrets map[string]string
-}
+// parseVar parses the contents of a template variable up to the closing delimiter.
+// parseVar should be called after the opening delimiter has been read. The next
+// character from the buffer should be the first character of the contents.
+//
+// when parseVar returns, the next character in the buffer is the first character
+// after the closing delimiter of the template variable.
+func (p *v2Parser) parseVar() (node, error) {
+	var buffer bytes.Buffer
 
-// InjectVars takes a map of template variables with their corresponding values. It replaces
-// the template variables with their values in the template.
-func (t templateV2) InjectVars(vars map[string]string) (SecretTemplate, error) {
-	secrets := make(map[string]string, len(t.secrets))
-	for k, template := range t.secrets {
-		secretpath, err := template.Inject(vars)
+	for p.next == ' ' {
+		err := p.readRune()
+		if err == io.EOF {
+			return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+		}
 		if err != nil {
 			return nil, err
 		}
-		secrets[k] = secretpath
 	}
 
-	return secretTemplateV2{
-		template: t.template,
-		secrets:  secrets,
-	}, nil
-}
+	for {
+		switch p.next {
+		case '}':
+			return variable{
+				key: buffer.String(),
+			}, nil
+		case ' ':
+			errIllegalVariableSpace := ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
+			err := p.forwardToClosing([]rune("}"))
+			if err == io.EOF {
+				return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+			}
+			if err != nil {
+				return nil, errIllegalVariableSpace
+			}
+			return variable{
+				key: buffer.String(),
+			}, nil
+		default:
+			if unicode.IsLetter(p.next) || unicode.IsDigit(p.next) || p.current == '_' {
+				buffer.WriteRune(p.next)
 
-// InjectSecrets takes a map of secret paths with their corresponding values. It replaces
-// the secret paths with the corresponding values in the template.
-func (t secretTemplateV2) InjectSecrets(secrets map[string]string) (string, error) {
-	keys := make(map[string]string, len(t.secrets))
-	for k, secretpath := range t.secrets {
-		v, ok := secrets[secretpath]
-		if !ok {
-			return "", fmt.Errorf("no value supplied for secret %s", secretpath)
+				err := p.readRune()
+				if err == io.EOF {
+					return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
 		}
-		keys[k] = v
 	}
-	return t.template.Inject(keys)
 }
 
-// Secrets returns a list of paths to secrets that are used in the template.
-func (t secretTemplateV2) Secrets() []string {
-	set := map[string]struct{}{}
-	for _, path := range t.secrets {
-		set[path] = struct{}{}
+// parseSecret parses the contents of a secret tag up to the closing delimiter.
+// parseSecret should be called after the opening delimiter has been read. The next
+// character from the buffer should be the first character of the contents.
+//
+// when parseSecret returns, the next character in the buffer is the first character
+// after the closing delimiter of the secret tag.
+func (p *v2Parser) parseSecret() (node, error) {
+	path := []node{}
+	err := p.readRune()
+	if err == io.EOF {
+		return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+	}
+	if err != nil {
+		return nil, err
+	}
+	for p.next == ' ' {
+		err = p.readRune()
+		if err == io.EOF {
+			return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	result := make([]string, len(set))
+	for {
+		err = p.readRune()
+		if err == io.EOF {
+			return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch p.current {
+		case '$':
+			switch p.next {
+			case '{':
+				err = p.readRune()
+				if err == io.EOF {
+					return nil, ErrVariableTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+				variable, err := p.parseVar()
+				if err != nil {
+					return nil, err
+				}
+				path = append(path, variable)
+
+				err = p.readRune()
+				if err == io.EOF {
+					return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
+				}
+				if err != nil {
+					return nil, err
+				}
+			default:
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+		case ' ':
+			err := p.forwardToClosing([]rune("}}"))
+			if err != nil {
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+			return secret{
+				path: path,
+			}, nil
+		case '}':
+			switch p.next {
+			case '}':
+				return secret{
+					path: path,
+				}, nil
+			default:
+				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			}
+		default:
+			if unicode.IsLetter(p.current) || unicode.IsDigit(p.current) || p.current == '_' || p.current == '-' || p.current == '.' || p.current == '/' || p.current == ':' {
+				path = append(path, character(p.current))
+				continue
+			}
+			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+		}
+	}
+}
+
+// forwardToClosing skips all spaces up to the closing delimiter.
+// It returns an error when characters other than spaces occur before the complete
+// closing delimiter occurs.
+func (p *v2Parser) forwardToClosing(delim []rune) error {
+	if len(delim) == 0 {
+		return errors.New("delim should be at least one character long")
+	}
+	for p.next == ' ' {
+		err := p.readRune()
+		if err != nil {
+			return err
+		}
+	}
 	i := 0
-	for path := range set {
-		result[i] = path
+	for {
+		if p.next != delim[i] {
+			return errors.New("expected end delimiter")
+		}
 		i++
+		if i < len(delim) {
+			err := p.readRune()
+			if err != nil {
+				return err
+			}
+		} else {
+			return nil
+		}
 	}
-	return result
+}
+
+// SecretReader fetches a secret by its path.
+type SecretReader interface {
+	ReadSecret(path string) (string, error)
+}
+
+// Evaluate renders a template. It replaces all variable- and secret tags in the template.
+func (t templateV2) Evaluate(vars map[string]string, sr SecretReader) (string, error) {
+	ctx := context{
+		vars:         vars,
+		secretReader: sr,
+	}
+
+	var buffer bytes.Buffer
+	for _, n := range t.nodes {
+		eval, err := n.evaluate(ctx)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(eval)
+	}
+	return buffer.String(), nil
 }

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -15,7 +15,12 @@ var (
 	ErrSecretTagNotClosed       = tplError.Code("secret_tag_not_closed").ErrorPref("Expected the closing of a secret tag `}}` at line %d column %d, but reached the end of the template.")
 	ErrVariableTagNotClosed     = tplError.Code("variable_tag_not_closed").ErrorPref("Expected the closing of a variable tag `}` at line %d column %d, but reached the end of the template.")
 
-	specialChars = []rune{'$', '{', '}', '\\'}
+	specialChars = map[rune]struct{}{
+		'$':  {},
+		'{':  {},
+		'}':  {},
+		'\\': {},
+	}
 )
 
 // NewV2Parser returns a parser for the v2 template syntax.
@@ -229,14 +234,7 @@ func (p *v2Parser) parse() ([]node, error) {
 				continue
 			}
 		case '\\':
-			isSpecialChar := false
-			for _, specialChar := range specialChars {
-				if p.next == specialChar {
-					isSpecialChar = true
-					break
-				}
-			}
-
+			_, isSpecialChar := specialChars[p.next]
 			if isSpecialChar {
 				res = append(res, character(p.next))
 

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -60,6 +60,7 @@ func (s secret) evaluate(ctx context) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		buffer.WriteString(eval)
 	}
 	return ctx.secret(buffer.String())
@@ -108,10 +109,12 @@ type parserV2 struct{}
 // Variable tags cannot contain variable tags (they cannot be nested).
 func (p parserV2) Parse(raw string, line, column int) (Template, error) {
 	parser := newV2Parser(bytes.NewBufferString(raw), line, column)
+
 	nodes, err := parser.parse()
 	if err != nil {
 		return nil, err
 	}
+
 	return templateV2{
 		nodes: nodes,
 	}, nil
@@ -154,6 +157,7 @@ func (p *v2Parser) readRune() error {
 
 func (p *v2Parser) parse() ([]node, error) {
 	res := []node{}
+
 	err := p.readRune()
 	if err == io.EOF {
 		return res, nil
@@ -179,6 +183,7 @@ func (p *v2Parser) parse() ([]node, error) {
 				if err != nil {
 					return nil, err
 				}
+
 				res = append(res, variable)
 
 				err = p.readRune()
@@ -196,6 +201,7 @@ func (p *v2Parser) parse() ([]node, error) {
 				if unicode.IsLetter(p.next) || p.next == '_' {
 					return nil, ErrUnexpectedDollar(p.lineNo, p.columnNo)
 				}
+
 				res = append(res, character(p.current))
 				continue
 			}
@@ -206,6 +212,7 @@ func (p *v2Parser) parse() ([]node, error) {
 				if err != nil {
 					return nil, err
 				}
+
 				res = append(res, secret)
 
 				err = p.readRune()
@@ -215,6 +222,7 @@ func (p *v2Parser) parse() ([]node, error) {
 				if err != nil {
 					return nil, err
 				}
+
 				continue
 			default:
 				res = append(res, character(p.current))
@@ -228,8 +236,10 @@ func (p *v2Parser) parse() ([]node, error) {
 					break
 				}
 			}
+
 			if isSpecialChar {
 				res = append(res, character(p.next))
+
 				err = p.readRune()
 				if err == io.EOF {
 					return res, nil
@@ -240,6 +250,7 @@ func (p *v2Parser) parse() ([]node, error) {
 			} else {
 				res = append(res, character(p.current))
 			}
+
 			continue
 		default:
 			res = append(res, character(p.current))
@@ -287,11 +298,13 @@ func (p *v2Parser) parseVar() (node, error) {
 			if err != nil {
 				return nil, err
 			}
+
 			if p.next == '}' {
 				return variable{
 					key: buffer.String(),
 				}, nil
 			}
+
 			return nil, ErrIllegalVariableCharacter(p.current, p.lineNo, p.columnNo)
 		}
 		if p.isVariableRune(p.next) {
@@ -304,6 +317,7 @@ func (p *v2Parser) parseVar() (node, error) {
 			if err != nil {
 				return nil, err
 			}
+
 			continue
 		}
 		return nil, ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
@@ -318,6 +332,7 @@ func (p *v2Parser) parseVar() (node, error) {
 // of the closing delimiter of the secret tag ('}').
 func (p *v2Parser) parseSecret() (node, error) {
 	path := []node{}
+
 	err := p.readRune()
 	if err == io.EOF {
 		return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
@@ -349,6 +364,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				if err != nil {
 					return nil, err
 				}
+
 				path = append(path, variable)
 
 				err = p.readRune()
@@ -358,6 +374,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				if err != nil {
 					return nil, err
 				}
+
 				continue
 			}
 			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
@@ -370,9 +387,11 @@ func (p *v2Parser) parseSecret() (node, error) {
 			if err != nil {
 				return nil, err
 			}
+
 			if p.next != '}' {
 				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
 			}
+
 			err = p.readRune()
 			if err == io.EOF {
 				return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
@@ -384,22 +403,27 @@ func (p *v2Parser) parseSecret() (node, error) {
 			if p.next != '}' {
 				return nil, ErrIllegalSecretCharacter(' ', p.lineNo, p.columnNo-1)
 			}
+
 			return secret{
 				path: path,
 			}, nil
 		}
+
 		if p.current == '}' {
 			if p.next == '}' {
 				return secret{
 					path: path,
 				}, nil
 			}
+
 			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
 		}
+
 		if p.isSecretPathRune(p.current) {
 			path = append(path, character(p.current))
 			continue
 		}
+
 		return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
 	}
 }
@@ -450,7 +474,9 @@ func (t templateV2) Evaluate(vars map[string]string, sr SecretReader) (string, e
 		if err != nil {
 			return "", err
 		}
+
 		buffer.WriteString(eval)
 	}
+
 	return buffer.String(), nil
 }

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -294,7 +294,7 @@ func (p *v2Parser) parseVar() (node, error) {
 			}
 			return nil, ErrIllegalVariableCharacter(p.current, p.lineNo, p.columnNo)
 		}
-		if unicode.IsLetter(p.next) || unicode.IsDigit(p.next) || p.current == '_' {
+		if p.isVariableRune(p.next) {
 			buffer.WriteRune(p.next)
 
 			err := p.readRune()
@@ -399,12 +399,23 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
 		}
-		if unicode.IsLetter(p.current) || unicode.IsDigit(p.current) || p.current == '_' || p.current == '-' || p.current == '.' || p.current == '/' || p.current == ':' {
+		if p.isSecretPathRune(p.current) {
 			path = append(path, character(p.current))
 			continue
 		}
 		return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
 	}
+}
+
+// isSecretPathRune returns whether the given rune is allowed to be used in
+// a secret path.
+func (p *v2Parser) isSecretPathRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' || r == '/' || r == ':'
+}
+
+// isVariableRune returns whether the given rune is allowed to be used in a template variable key.
+func (p *v2Parser) isVariableRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
 }
 
 // isAllowedWhiteSpace returns whether the given rune is allowed as extra whitespace

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -12,7 +12,7 @@ var (
 	ErrTemplateVarNotFound      = tplError.Code("template_var_not_found").ErrorPref("no value was supplied for template variable '%s'")
 	ErrUnexpectedDollar         = tplError.Code("unexpected_character").ErrorPref("unexpected '$' at line %d column %d. Use '\\$' if you want to output a dollar sign.")
 	ErrIllegalVariableCharacter = tplError.Code("illegal_variable_character").ErrorPref("Illegal character '%s' at line %d column %d. Variable names can only contain letters, digits and underscores.")
-	ErrIllegalSecretCharacter   = tplError.Code("illegal_secret_character").ErrorPref("Illegel character '%s' at line %d column %d. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.")
+	ErrIllegalSecretCharacter   = tplError.Code("illegal_secret_character").ErrorPref("Illegal character '%s' at line %d column %d. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.")
 	ErrSecretTagNotClosed       = tplError.Code("secret_tag_not_closed").ErrorPref("Expected the closing of a secret tag `}}` at line %d column %d, but reached the end of the template.")
 	ErrVariableTagNotClosed     = tplError.Code("variable_tag_not_closed").ErrorPref("Expected the closing of a variable tag `}` at line %d column %d, but reached the end of the template.")
 

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -123,7 +123,7 @@ func newV2Parser(buf *bytes.Buffer, line, column int) v2Parser {
 		buf:    buf,
 		lineNo: line,
 		// The column number indicates the index (starting at 1) of the current rune.
-		// We subtract 2 of the given value. One bacause we have not read the current rune yet and
+		// We subtract 2 of the given value. One because we have not read the current rune yet and
 		// one more because we are reading the next rune in advance (which we don't want to count).
 		columnNo: column - 2,
 	}

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -241,6 +241,8 @@ func (p *v2Parser) parseVar() (node, error) {
 		}
 
 		if p.isAllowedWhiteSpace(p.next) {
+			whitespace := p.next
+			columnNo := p.columnNo + 1
 			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
@@ -252,7 +254,7 @@ func (p *v2Parser) parseVar() (node, error) {
 				}, nil
 			}
 
-			return nil, ErrIllegalVariableCharacter(p.lineNo, p.columnNo, p.current)
+			return nil, ErrIllegalVariableCharacter(p.lineNo, columnNo, whitespace)
 		}
 
 		if p.isVariableRune(p.next) {
@@ -321,13 +323,15 @@ func (p *v2Parser) parseSecret() (node, error) {
 			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 		}
 		if p.isAllowedWhiteSpace(p.current) {
+			whitespace := p.current
+			columnNo := p.columnNo
 			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
 			}
 
 			if p.next != token.RBracket {
-				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
+				return nil, ErrIllegalSecretCharacter(p.lineNo, columnNo, whitespace)
 			}
 
 			err = checkError(p.readRune())
@@ -336,7 +340,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 
 			if p.next != token.RBracket {
-				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo-1, ' ')
+				return nil, ErrIllegalSecretCharacter(p.lineNo, columnNo, whitespace)
 			}
 
 			return secret{

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -285,6 +285,7 @@ func (p *v2Parser) parseVar() (node, error) {
 				key: buffer.String(),
 			}, nil
 		}
+
 		if p.isAllowedWhiteSpace(p.next) {
 			err := p.skipWhiteSpace()
 			if err == io.EOF {
@@ -302,6 +303,7 @@ func (p *v2Parser) parseVar() (node, error) {
 
 			return nil, ErrIllegalVariableCharacter(p.current, p.lineNo, p.columnNo)
 		}
+
 		if p.isVariableRune(p.next) {
 			buffer.WriteRune(p.next)
 
@@ -315,6 +317,7 @@ func (p *v2Parser) parseVar() (node, error) {
 
 			continue
 		}
+
 		return nil, ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
 	}
 }

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -316,7 +316,7 @@ func (p *v2Parser) parseVar() (node, error) {
 // parseSecret should be called after the opening delimiter has been read. The next
 // character from the buffer should be the first character of the contents.
 //
-// when parseSecret returns, the next character in the buffer is the first character
+// When parseSecret returns, the next character in the buffer is the first character
 // after the closing delimiter of the secret tag.
 func (p *v2Parser) parseSecret() (node, error) {
 	path := []node{}

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -241,8 +241,6 @@ func (p *v2Parser) parseVar() (node, error) {
 		}
 
 		if p.isAllowedWhiteSpace(p.next) {
-			whitespace := p.next
-			columnNo := p.columnNo + 1
 			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
@@ -254,7 +252,7 @@ func (p *v2Parser) parseVar() (node, error) {
 				}, nil
 			}
 
-			return nil, ErrIllegalVariableCharacter(p.lineNo, columnNo, whitespace)
+			return nil, ErrUnexpectedCharacter(p.lineNo, p.columnNo+1, p.next, token.RBracket)
 		}
 
 		if p.isVariableRune(p.next) {
@@ -322,16 +320,15 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 		}
+
 		if p.isAllowedWhiteSpace(p.current) {
-			whitespace := p.current
-			columnNo := p.columnNo
 			err := checkError(p.skipWhiteSpace())
 			if err != nil {
 				return nil, err
 			}
 
 			if p.next != token.RBracket {
-				return nil, ErrIllegalSecretCharacter(p.lineNo, columnNo, whitespace)
+				return nil, ErrUnexpectedCharacter(p.lineNo, p.columnNo+1, p.next, token.RBracket)
 			}
 
 			err = checkError(p.readRune())
@@ -340,7 +337,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 
 			if p.next != token.RBracket {
-				return nil, ErrIllegalSecretCharacter(p.lineNo, columnNo, whitespace)
+				return nil, ErrUnexpectedCharacter(p.lineNo, p.columnNo+1, p.next, token.RBracket)
 			}
 
 			return secret{
@@ -354,8 +351,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 					path: path,
 				}, nil
 			}
-
-			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
+			return nil, ErrUnexpectedCharacter(p.lineNo, p.columnNo+1, p.next, token.RBracket)
 		}
 
 		if p.isSecretPathRune(p.current) {

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -377,6 +377,10 @@ func (p *v2Parser) parseSecret() (node, error) {
 			if err == io.EOF {
 				return nil, ErrSecretTagNotClosed(p.lineNo, p.columnNo+1)
 			}
+			if err != nil {
+				return nil, err
+			}
+
 			if p.next != '}' {
 				return nil, ErrIllegalSecretCharacter(' ', p.lineNo, p.columnNo-1)
 			}

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -8,13 +8,6 @@ import (
 
 // Errors
 var (
-	ErrTemplateVarNotFound      = tplError.Code("template_var_not_found").ErrorPref("no value was supplied for template variable '%s'")
-	ErrUnexpectedDollar         = tplError.Code("unexpected_character").ErrorPref("unexpected '$' at line %d column %d. Use '\\$' if you want to output a dollar sign.")
-	ErrIllegalVariableCharacter = tplError.Code("illegal_variable_character").ErrorPref("Illegal character '%s' at line %d column %d. Variable names can only contain letters, digits and underscores.")
-	ErrIllegalSecretCharacter   = tplError.Code("illegal_secret_character").ErrorPref("Illegal character '%s' at line %d column %d. Secret paths can only contain letters, digits, underscores, hypens, dots, slashes and a colon.")
-	ErrSecretTagNotClosed       = tplError.Code("secret_tag_not_closed").ErrorPref("Expected the closing of a secret tag `}}` at line %d column %d, but reached the end of the template.")
-	ErrVariableTagNotClosed     = tplError.Code("variable_tag_not_closed").ErrorPref("Expected the closing of a variable tag `}` at line %d column %d, but reached the end of the template.")
-
 	specialChars = map[rune]struct{}{
 		'$':  {},
 		'{':  {},
@@ -301,7 +294,7 @@ func (p *v2Parser) parseVar() (node, error) {
 				}, nil
 			}
 
-			return nil, ErrIllegalVariableCharacter(p.current, p.lineNo, p.columnNo)
+			return nil, ErrIllegalVariableCharacter(p.lineNo, p.columnNo, p.current)
 		}
 
 		if p.isVariableRune(p.next) {
@@ -318,7 +311,7 @@ func (p *v2Parser) parseVar() (node, error) {
 			continue
 		}
 
-		return nil, ErrIllegalVariableCharacter(p.next, p.lineNo, p.columnNo+1)
+		return nil, ErrIllegalVariableCharacter(p.lineNo, p.columnNo+1, p.next)
 	}
 }
 
@@ -375,7 +368,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 
 				continue
 			}
-			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 		}
 		if p.isAllowedWhiteSpace(p.current) {
 			err := p.skipWhiteSpace()
@@ -387,7 +380,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 
 			if p.next != '}' {
-				return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 			}
 
 			err = p.readRune()
@@ -399,7 +392,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			}
 
 			if p.next != '}' {
-				return nil, ErrIllegalSecretCharacter(' ', p.lineNo, p.columnNo-1)
+				return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo-1, ' ')
 			}
 
 			return secret{
@@ -414,7 +407,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 				}, nil
 			}
 
-			return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+			return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 		}
 
 		if p.isSecretPathRune(p.current) {
@@ -422,7 +415,7 @@ func (p *v2Parser) parseSecret() (node, error) {
 			continue
 		}
 
-		return nil, ErrIllegalSecretCharacter(p.current, p.lineNo, p.columnNo)
+		return nil, ErrIllegalSecretCharacter(p.lineNo, p.columnNo, p.current)
 	}
 }
 

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -391,39 +391,39 @@ func TestParserV2_parse(t *testing.T) {
 		},
 		"illegal variable space": {
 			input: "${ va r }",
-			err:   ErrIllegalVariableCharacter(' ', 1, 6),
+			err:   ErrIllegalVariableCharacter(1, 6, ' '),
 		},
 		"illegal secret space": {
 			input: "{{ secret with space }}",
-			err:   ErrIllegalSecretCharacter(' ', 1, 10),
+			err:   ErrIllegalSecretCharacter(1, 10, ' '),
 		},
 		"illegal secret space followed by bracket": {
 			input: "{{ secret }with space }}",
-			err:   ErrIllegalSecretCharacter(' ', 1, 10),
+			err:   ErrIllegalSecretCharacter(1, 10, ' '),
 		},
 		"illegal variable character": {
 			input: "${ var@var }",
-			err:   ErrIllegalVariableCharacter('@', 1, 7),
+			err:   ErrIllegalVariableCharacter(1, 7, '@'),
 		},
 		"illegal secret character": {
 			input: "{{ a@b }}",
-			err:   ErrIllegalSecretCharacter('@', 1, 5),
+			err:   ErrIllegalSecretCharacter(1, 5, '@'),
 		},
 		"illegal { at start of secret tag": {
 			input: "{{{ path/to/secret }}}",
-			err:   ErrIllegalSecretCharacter('{', 1, 3),
+			err:   ErrIllegalSecretCharacter(1, 3, '{'),
 		},
 		"illegal secret character $": {
 			input: "{{ a$b }}",
-			err:   ErrIllegalSecretCharacter('$', 1, 5),
+			err:   ErrIllegalSecretCharacter(1, 5, '$'),
 		},
 		"illegal variable char in secret tag": {
 			input: "{{ path/with/${var@b} }}",
-			err:   ErrIllegalVariableCharacter('@', 1, 19),
+			err:   ErrIllegalVariableCharacter(1, 19, '@'),
 		},
 		"error on new line": {
 			input: "{{ path/to/secret }}\n{{ a%b }}",
-			err:   ErrIllegalSecretCharacter('%', 2, 5),
+			err:   ErrIllegalSecretCharacter(2, 5, '%'),
 		},
 		"secret tag not closed": {
 			input: "{{ path",

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -390,6 +390,10 @@ func TestParserV2_parse(t *testing.T) {
 			input: "{{ a@b }}",
 			err:   ErrIllegalSecretCharacter('@', 1, 5),
 		},
+		"illegal { at start of secret tag": {
+			input: "{{{ path/to/secret }}}",
+			err:   ErrIllegalSecretCharacter('{', 1, 3),
+		},
 		"illegal secret character $": {
 			input: "{{ a$b }}",
 			err:   ErrIllegalSecretCharacter('$', 1, 5),

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -395,43 +395,43 @@ func TestParserV2_parse(t *testing.T) {
 		},
 		"illegal variable space": {
 			input: "${ va r }",
-			err:   ErrIllegalVariableCharacter(1, 6, ' '),
+			err:   ErrUnexpectedCharacter(1, 7, 'r', '}'),
 		},
 		"illegal double variable space": {
 			input: "${ va  r }",
-			err:   ErrIllegalVariableCharacter(1, 6, ' '),
+			err:   ErrUnexpectedCharacter(1, 8, 'r', '}'),
 		},
 		"illegal variable tab": {
 			input: "${ va\tr }",
-			err:   ErrIllegalVariableCharacter(1, 6, '\t'),
+			err:   ErrUnexpectedCharacter(1, 7, 'r', '}'),
 		},
 		"illegal variable tab followed by space": {
 			input: "${ va\t r }",
-			err:   ErrIllegalVariableCharacter(1, 6, '\t'),
+			err:   ErrUnexpectedCharacter(1, 8, 'r', '}'),
 		},
 		"illegal secret space": {
 			input: "{{ secret with space }}",
-			err:   ErrIllegalSecretCharacter(1, 10, ' '),
+			err:   ErrUnexpectedCharacter(1, 11, 'w', '}'),
 		},
 		"illegal secret space followed by bracket": {
 			input: "{{ secret }with space }}",
-			err:   ErrIllegalSecretCharacter(1, 10, ' '),
+			err:   ErrUnexpectedCharacter(1, 12, 'w', '}'),
 		},
 		"illegal secret tab": {
 			input: "{{ secret\twith a tab }}",
-			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
+			err:   ErrUnexpectedCharacter(1, 11, 'w', '}'),
 		},
 		"illegal secret tab followed by bracket": {
 			input: "{{ secret\t}with tab }}",
-			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
+			err:   ErrUnexpectedCharacter(1, 12, 'w', '}'),
 		},
 		"illegal double secret space": {
 			input: "{{ secret  with two spaces }}",
-			err:   ErrIllegalSecretCharacter(1, 10, ' '),
+			err:   ErrUnexpectedCharacter(1, 12, 'w', '}'),
 		},
 		"illegal secret tab followed by space": {
 			input: "{{ secret\t with tab and space }}",
-			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
+			err:   ErrUnexpectedCharacter(1, 12, 'w', '}'),
 		},
 		"illegal variable character": {
 			input: "${ var@var }",
@@ -488,6 +488,10 @@ func TestParserV2_parse(t *testing.T) {
 		"secret tag not closed after first bracket": {
 			input: "{{ foo/bar }",
 			err:   ErrSecretTagNotClosed(1, 13),
+		},
+		"secret tag not closed after first bracket, continue": {
+			input: "{{ foo/bar }baz",
+			err:   ErrUnexpectedCharacter(1, 13, 'b', '}'),
 		},
 		"variable tag not closed": {
 			input: "${ var",

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -1,12 +1,459 @@
-package tpl_test
+package tpl
 
 import (
+	"bytes"
 	"testing"
 
-	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
-	generictpl "github.com/secrethub/secrethub-cli/internals/tpl"
+	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl/fakes"
+
 	"github.com/secrethub/secrethub-go/internals/assert"
 )
+
+func TestParserV2_parse(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected []node
+		err      error
+	}{
+		"no vars, no secrets": {
+			input: "hello world",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"start with var": {
+			input: "${var} world",
+			expected: []node{
+				variable{
+					key: "var",
+				},
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"end with var": {
+			input: "hello ${var}",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				variable{
+					key: "var",
+				},
+			},
+		},
+		"var in middle": {
+			input: "hello ${var} world",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				variable{
+					key: "var",
+				},
+				character(' '),
+				character('w'),
+				character('o'),
+				character('r'),
+				character('l'),
+				character('d'),
+			},
+		},
+		"secret path": {
+			input: "{{path/to/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"secret path in middle": {
+			input: "hello {{path/to/secret}} secret",
+			expected: []node{
+				character('h'),
+				character('e'),
+				character('l'),
+				character('l'),
+				character('o'),
+				character(' '),
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+				character(' '),
+				character('s'),
+				character('e'),
+				character('c'),
+				character('r'),
+				character('e'),
+				character('t'),
+			},
+		},
+		"variable in secret path at start": {
+			input: "{{${var}/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						variable{
+							key: "var",
+						},
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"variable in secret path at end": {
+			input: "{{secret${var}}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+						variable{
+							key: "var",
+						},
+					},
+				},
+			},
+		},
+		"variable in secret path at end with space": {
+			input: "{{ secret${var} }}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+						variable{
+							key: "var",
+						},
+					},
+				},
+			},
+		},
+		"variable in secret path in middle": {
+			input: "{{path/to/${var}/secret}}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						variable{
+							key: "var",
+						},
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"variable with spaces": {
+			input: "${ var }",
+			expected: []node{
+				variable{
+					key: "var",
+				},
+			},
+		},
+		"secret with spaces": {
+			input: "{{ path/to/secret }}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('p'),
+						character('a'),
+						character('t'),
+						character('h'),
+						character('/'),
+						character('t'),
+						character('o'),
+						character('/'),
+						character('s'),
+						character('e'),
+						character('c'),
+						character('r'),
+						character('e'),
+						character('t'),
+					},
+				},
+			},
+		},
+		"{ and } chars used": {
+			input: `{"key": "value"}`,
+			expected: []node{
+				character('{'),
+				character('"'),
+				character('k'),
+				character('e'),
+				character('y'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('"'),
+				character('v'),
+				character('a'),
+				character('l'),
+				character('u'),
+				character('e'),
+				character('"'),
+				character('}'),
+			},
+		},
+		"}} used outside secret tag": {
+			input: `{"a": {"b": "c"}}`,
+			expected: []node{
+				character('{'),
+				character('"'),
+				character('a'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('{'),
+				character('"'),
+				character('b'),
+				character('"'),
+				character(':'),
+				character(' '),
+				character('"'),
+				character('c'),
+				character('"'),
+				character('}'),
+				character('}'),
+			},
+		},
+		"$ used": {
+			input: `$12.50`,
+			expected: []node{
+				character('$'),
+				character('1'),
+				character('2'),
+				character('.'),
+				character('5'),
+				character('0'),
+			},
+		},
+		"escaped dollar": {
+			input: `\$`,
+			expected: []node{
+				character('$'),
+			},
+		},
+		"escaped dollar + bracket": {
+			input: `\${var}`,
+			expected: []node{
+				character('$'),
+				character('{'),
+				character('v'),
+				character('a'),
+				character('r'),
+				character('}'),
+			},
+		},
+		"escaped double bracket": {
+			input: `\{{ path }}`,
+			expected: []node{
+				character('{'),
+				character('{'),
+				character(' '),
+				character('p'),
+				character('a'),
+				character('t'),
+				character('h'),
+				character(' '),
+				character('}'),
+				character('}'),
+			},
+		},
+		"escaped backslash": {
+			input: `\\`,
+			expected: []node{
+				character('\\'),
+			},
+		},
+		"escaped opening bracket": {
+			input: `\{`,
+			expected: []node{
+				character('{'),
+			},
+		},
+		"escaped closing bracket": {
+			input: `\}`,
+			expected: []node{
+				character('}'),
+			},
+		},
+		"backslash followed by letter": {
+			input: `\a`,
+			expected: []node{
+				character('\\'),
+				character('a'),
+			},
+		},
+		"$ followed by lowercase letter": {
+			input: "$var",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"$ followed by uppercase letter": {
+			input: "$VAR",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"$ followed by underscore": {
+			input: "$_var",
+			err:   ErrUnexpectedDollar(1, 1),
+		},
+		"illegal variable space": {
+			input: "${ va r }",
+			err:   ErrIllegalVariableCharacter(' ', 1, 6),
+		},
+		"illegal secret space": {
+			input: "{{ secret with space }}",
+			err:   ErrIllegalSecretCharacter(' ', 1, 10),
+		},
+		"illegal variable character": {
+			input: "${ var@var }",
+			err:   ErrIllegalVariableCharacter('@', 1, 7),
+		},
+		"illegal secret character": {
+			input: "{{ a@b }}",
+			err:   ErrIllegalSecretCharacter('@', 1, 5),
+		},
+		"illegal secret character $": {
+			input: "{{ a$b }}",
+			err:   ErrIllegalSecretCharacter('$', 1, 5),
+		},
+		"illegal variable char in secret tag": {
+			input: "{{ path/with/${var@b} }}",
+			err:   ErrIllegalVariableCharacter('@', 1, 19),
+		},
+		"error on new line": {
+			input: "{{ path/to/secret }}\n{{ a%b }}",
+			err:   ErrIllegalSecretCharacter('%', 2, 5),
+		},
+		"secret tag not closed": {
+			input: "{{ path",
+			err:   ErrSecretTagNotClosed(1, 8),
+		},
+		"secret tag not closed after space at end": {
+			input: "{{ path ",
+			err:   ErrSecretTagNotClosed(1, 9),
+		},
+		"secret tag not closed after space at start": {
+			input: "{{ ",
+			err:   ErrSecretTagNotClosed(1, 4),
+		},
+		"secret tag not closed at start of tag": {
+			input: "{{",
+			err:   ErrSecretTagNotClosed(1, 3),
+		},
+		"secret tag not closed after var end": {
+			input: "{{ foo/${var}",
+			err:   ErrSecretTagNotClosed(1, 14),
+		},
+		"secret tag not closed after space after var": {
+			input: "{{ foo/${var} ",
+			err:   ErrSecretTagNotClosed(1, 15),
+		},
+		"variable tag not closed": {
+			input: "${ var",
+			err:   ErrVariableTagNotClosed(1, 7),
+		},
+		"variable tag not closed after space at start": {
+			input: "${ ",
+			err:   ErrVariableTagNotClosed(1, 4),
+		},
+		"variable tag not closed after space at end": {
+			input: "${ var ",
+			err:   ErrVariableTagNotClosed(1, 8),
+		},
+		"variable tag not closed at start of tag": {
+			input: "${",
+			err:   ErrVariableTagNotClosed(1, 3),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			parser := newV2Parser(bytes.NewBufferString(tc.input), 1, 1)
+			actual, err := parser.parse()
+
+			assert.Equal(t, actual, tc.expected)
+			assert.Equal(t, err, tc.err)
+		})
+	}
+}
 
 func TestV2(t *testing.T) {
 	cases := map[string]struct {
@@ -14,10 +461,9 @@ func TestV2(t *testing.T) {
 		vars    map[string]string
 		secrets map[string]string
 
-		expected         string
-		parseErr         error
-		injectVarsErr    error
-		injectSecretsErr error
+		expected string
+		parseErr error
+		evalErr  error
 	}{
 		"no secrets": {
 			raw:      "hello world",
@@ -30,7 +476,7 @@ func TestV2(t *testing.T) {
 			},
 			expected: "hello world",
 		},
-		"template var": {
+		"template var in secret": {
 			raw: "hello {{ ${app}/greeting }}",
 			vars: map[string]string{
 				"app": "company/helloworld",
@@ -40,34 +486,45 @@ func TestV2(t *testing.T) {
 			},
 			expected: "hello world",
 		},
+		"end with template var": {
+			raw: "hello {{company/helloworld/${greeting}}}",
+			vars: map[string]string{
+				"greeting": "hello",
+			},
+			secrets: map[string]string{
+				"company/helloworld/hello": "world",
+			},
+			expected: "hello world",
+		},
 		"missing var": {
 			raw:  "hello {{ ${app}/greeting }}",
 			vars: map[string]string{},
 			secrets: map[string]string{
 				"company/helloworld/greeting": "world",
 			},
-			injectVarsErr: generictpl.ErrKeyNotFound("app"),
+			evalErr: ErrTemplateVarNotFound("app"),
+		},
+		"missing var with spaces": {
+			raw:  "hello {{ ${ app }/greeting }}",
+			vars: map[string]string{},
+			secrets: map[string]string{
+				"company/helloworld/greeting": "world",
+			},
+			evalErr: ErrTemplateVarNotFound("app"),
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			parsed, err := tpl.NewV2Parser().Parse(tc.raw)
+			parsed, err := NewV2Parser().Parse(tc.raw, 1, 1)
 			assert.Equal(t, err, tc.parseErr)
 
 			if err != nil {
 				return
 			}
 
-			varsInjected, err := parsed.InjectVars(tc.vars)
-			assert.Equal(t, err, tc.injectVarsErr)
-
-			if err != nil {
-				return
-			}
-
-			actual, err := varsInjected.InjectSecrets(tc.secrets)
-			assert.Equal(t, err, tc.injectSecretsErr)
+			actual, err := parsed.Evaluate(tc.vars, fakes.FakeSecretReader{Secrets: tc.secrets})
+			assert.Equal(t, err, tc.evalErr)
 			assert.Equal(t, actual, tc.expected)
 		})
 	}

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -397,6 +397,18 @@ func TestParserV2_parse(t *testing.T) {
 			input: "${ va r }",
 			err:   ErrIllegalVariableCharacter(1, 6, ' '),
 		},
+		"illegal double variable space": {
+			input: "${ va  r }",
+			err:   ErrIllegalVariableCharacter(1, 6, ' '),
+		},
+		"illegal variable tab": {
+			input: "${ va\tr }",
+			err:   ErrIllegalVariableCharacter(1, 6, '\t'),
+		},
+		"illegal variable tab followed by space": {
+			input: "${ va\t r }",
+			err:   ErrIllegalVariableCharacter(1, 6, '\t'),
+		},
 		"illegal secret space": {
 			input: "{{ secret with space }}",
 			err:   ErrIllegalSecretCharacter(1, 10, ' '),
@@ -404,6 +416,22 @@ func TestParserV2_parse(t *testing.T) {
 		"illegal secret space followed by bracket": {
 			input: "{{ secret }with space }}",
 			err:   ErrIllegalSecretCharacter(1, 10, ' '),
+		},
+		"illegal secret tab": {
+			input: "{{ secret\twith a tab }}",
+			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
+		},
+		"illegal secret tab followed by bracket": {
+			input: "{{ secret\t}with tab }}",
+			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
+		},
+		"illegal double secret space": {
+			input: "{{ secret  with two spaces }}",
+			err:   ErrIllegalSecretCharacter(1, 10, ' '),
+		},
+		"illegal secret tab followed by space": {
+			input: "{{ secret\t with tab and space }}",
+			err:   ErrIllegalSecretCharacter(1, 10, '\t'),
 		},
 		"illegal variable character": {
 			input: "${ var@var }",

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -138,6 +138,21 @@ func TestParserV2_parse(t *testing.T) {
 				character('t'),
 			},
 		},
+		"two secret tags": {
+			input: "{{ a }}{{ b }}",
+			expected: []node{
+				secret{
+					path: []node{
+						character('a'),
+					},
+				},
+				secret{
+					path: []node{
+						character('b'),
+					},
+				},
+			},
+		},
 		"variable in secret path at start": {
 			input: "{{${var}/secret}}",
 			expected: []node{
@@ -382,6 +397,10 @@ func TestParserV2_parse(t *testing.T) {
 			input: "{{ secret with space }}",
 			err:   ErrIllegalSecretCharacter(' ', 1, 10),
 		},
+		"illegal secret space followed by bracket": {
+			input: "{{ secret }with space }}",
+			err:   ErrIllegalSecretCharacter(' ', 1, 10),
+		},
 		"illegal variable character": {
 			input: "${ var@var }",
 			err:   ErrIllegalVariableCharacter('@', 1, 7),
@@ -429,6 +448,10 @@ func TestParserV2_parse(t *testing.T) {
 		"secret tag not closed after space after var": {
 			input: "{{ foo/${var} ",
 			err:   ErrSecretTagNotClosed(1, 15),
+		},
+		"secret tag not closed after first bracket": {
+			input: "{{ foo/bar }",
+			err:   ErrSecretTagNotClosed(1, 13),
 		},
 		"variable tag not closed": {
 			input: "${ var",

--- a/internals/secrethub/tpl/v2_test.go
+++ b/internals/secrethub/tpl/v2_test.go
@@ -15,6 +15,10 @@ func TestParserV2_parse(t *testing.T) {
 		expected []node
 		err      error
 	}{
+		"empty input": {
+			input:    "",
+			expected: []node{},
+		},
 		"no vars, no secrets": {
 			input: "hello world",
 			expected: []node{
@@ -432,6 +436,10 @@ func TestParserV2_parse(t *testing.T) {
 		"secret tag not closed after space at end": {
 			input: "{{ path ",
 			err:   ErrSecretTagNotClosed(1, 9),
+		},
+		"secret tag not closed after multiple space at end": {
+			input: "{{ path  ",
+			err:   ErrSecretTagNotClosed(1, 10),
 		},
 		"secret tag not closed after space at start": {
 			input: "{{ ",


### PR DESCRIPTION
This fixes a bug where the closing of a template variable tag
just before the closing of a secret tag returned an error.
Example: {{path/to/secret/${var}}}

The secret templates are now parsed in one go instead of parsing
secret tags first and then parsing the contents of the tag to
look for variables.

The secret template parsing now returns richer error messages, that
include line- and column number where the error occured.

More validation on the contents of the secret- and variable tags
is done while parsing. These errors also include line- and column
number.

dollar signs ($) with a letter, digit or underscore following must
be escaped. This is so that we can add variable support without
brackets later ($var).

$, {, } and \ characters can now be escaped.

Lots of testcases for the parser are added.