### PR TITLE
Release v0.24.1

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -137,17 +137,17 @@ func (cmd *RunCommand) Run() error {
 		}
 	}
 
-	raw, err := ioutil.ReadFile(cmd.envFile)
-	if err != nil {
-		return ErrCannotReadFile(err)
-	}
-
-	parser, err := getTemplateParser(raw, cmd.templateVersion)
-	if err != nil {
-		return err
-	}
-
 	if cmd.envFile != "" {
+		raw, err := ioutil.ReadFile(cmd.envFile)
+		if err != nil {
+			return ErrCannotReadFile(err)
+		}
+
+		parser, err := getTemplateParser(raw, cmd.templateVersion)
+		if err != nil {
+			return err
+		}
+
 		envFile, err := ReadEnvFile(cmd.envFile, templateVars, parser)
 		if err != nil {
 			return err

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -415,7 +415,7 @@ func TestNewEnv(t *testing.T) {
 			err: ErrTemplate(1, errors.New("template is not formatted as key=value pairs")),
 		},
 		"yml secret template error": {
-			raw: "foo: ${path/to/secret",
+			raw: "foo: ${path/to/secret\nbar: ${ path/to/secret }",
 			err: generictpl.ErrTagNotClosed("}"),
 		},
 		"secret template error": {
@@ -430,7 +430,10 @@ func TestNewEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			env, err := NewEnv(strings.NewReader(tc.raw), tc.templateVars, nil)
+			parser, err := getTemplateParser([]byte(tc.raw), "auto")
+			assert.OK(t, err)
+
+			env, err := NewEnv(strings.NewReader(tc.raw), tc.templateVars, parser)
 			if err != nil {
 				assert.Equal(t, err, tc.err)
 			} else {

--- a/internals/secrethub/template.go
+++ b/internals/secrethub/template.go
@@ -1,0 +1,23 @@
+package secrethub
+
+import (
+	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
+)
+
+func getTemplateParser(raw []byte, version string) (tpl.Parser, error) {
+	switch version {
+	case "auto":
+		if tpl.IsV1Template(raw) {
+			return tpl.NewV1Parser(), nil
+		}
+		return tpl.NewParser(), nil
+	case "1", "v1":
+		return tpl.NewV1Parser(), nil
+	case "2", "v2":
+		return tpl.NewV2Parser(), nil
+	case "latest":
+		return tpl.NewParser(), nil
+	default:
+		return nil, ErrUnknownTemplateVersion(version)
+	}
+}

--- a/internals/secrethub/tpl/template.go
+++ b/internals/secrethub/tpl/template.go
@@ -1,6 +1,10 @@
 package tpl
 
-import "github.com/secrethub/secrethub-go/internals/errio"
+import (
+	"regexp"
+
+	"github.com/secrethub/secrethub-go/internals/errio"
+)
 
 // Errors
 var (
@@ -22,4 +26,11 @@ type Template interface {
 // NewParser returns a parser for the latest template syntax.
 func NewParser() Parser {
 	return NewV2Parser()
+}
+
+var v1SecretTag = regexp.MustCompile(`\${[\t ]*[_\-\.a-zA-Z0-9]+/[_\-\.a-zA-Z0-9]+(?:/[_\-\.a-zA-Z0-9]+)+(?::(?:[0-9]{1,9}|latest))?[\t ]*}`)
+
+// IsV1Template returns whether v1 secret tags are used in the given raw bytes.
+func IsV1Template(raw []byte) bool {
+	return v1SecretTag.Match(raw)
 }

--- a/internals/secrethub/tpl/template_test.go
+++ b/internals/secrethub/tpl/template_test.go
@@ -1,0 +1,59 @@
+package tpl
+
+import (
+	"testing"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+)
+
+func TestDetectVersion(t *testing.T) {
+	cases := map[string]struct {
+		raw      string
+		expected bool
+	}{
+		"v1 tag without spaces": {
+			raw:      "${path/to/secret}",
+			expected: true,
+		},
+		"v1 tag with spaces": {
+			raw:      "${ path/to/secret }",
+			expected: true,
+		},
+		"v1 tag with version": {
+			raw:      "${ path/to/secret:1 }",
+			expected: true,
+		},
+		"v1 tag with latest version": {
+			raw:      "${ path/to/secret:latest }",
+			expected: true,
+		},
+		"v1 tag with 1 dir": {
+			raw:      "${ path/to/dir/secret }",
+			expected: true,
+		},
+		"v2 variable": {
+			raw:      "${var}foo",
+			expected: false,
+		},
+		"v2 unescaped var": {
+			raw:      "$var",
+			expected: false,
+		},
+		"v1 tag with tabs": {
+			raw:      "${\tpath/to/secret\t}",
+			expected: true,
+		},
+		"v1 tag without secret path": { // This is invalid in both template syntaxes
+			raw:      "${ namespace/repo }",
+			expected: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := IsV1Template([]byte(tc.raw))
+
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}

--- a/internals/secrethub/tpl/template_test.go
+++ b/internals/secrethub/tpl/template_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/secrethub/secrethub-go/internals/assert"
 )
 
-func TestDetectVersion(t *testing.T) {
+func TestIsV1Template(t *testing.T) {
 	cases := map[string]struct {
 		raw      string
 		expected bool


### PR DESCRIPTION
### Fixed
- Undo breaking change of `v0.24.0`: Auto detect the template syntax version to use instead of defaulting to the new template syntax.