### PR TITLE
Remove calls to errio.Error

### DIFF
--- a/internals/cli/configuration/configuration.go
+++ b/internals/cli/configuration/configuration.go
@@ -36,7 +36,7 @@ var (
 func ReadFromFile(path string, destination interface{}) error {
 	data, err := readFile(path)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return Read(data, destination)
@@ -45,7 +45,7 @@ func ReadFromFile(path string, destination interface{}) error {
 // Read attempts to read a config in a destination interface.
 func Read(data []byte, destination interface{}) error {
 	err := yaml.Unmarshal(data, destination)
-	return errio.Error(err)
+	return err
 }
 
 // ReadConfigurationDataFromFile retrieves the data and attempts to read the config as a ConfigMap
@@ -54,7 +54,7 @@ func Read(data []byte, destination interface{}) error {
 func ReadConfigurationDataFromFile(path string) (ConfigMap, []byte, error) {
 	data, err := readFile(path)
 	if err != nil {
-		return nil, nil, errio.Error(err)
+		return nil, nil, err
 	}
 
 	configMap, err := ReadMap(data)
@@ -97,7 +97,7 @@ func ParseMap(src *ConfigMap, dst interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&c)
 
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return decoder.Decode(src)

--- a/internals/cli/configuration/migrater.go
+++ b/internals/cli/configuration/migrater.go
@@ -2,7 +2,6 @@ package configuration
 
 import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 var (
@@ -39,7 +38,7 @@ func MigrateConfigTo(io ui.IO, config ConfigMap, versionFrom int, versionTo int,
 		}
 
 		if err != nil {
-			return config, errio.Error(err)
+			return config, err
 		}
 		if !migrated {
 			return config, ErrVersionNotReachable

--- a/internals/cli/env.go
+++ b/internals/cli/env.go
@@ -9,7 +9,6 @@ import (
 
 	"bitbucket.org/zombiezen/cardcpx/natsort"
 	"github.com/alecthomas/kingpin"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 var (
@@ -143,7 +142,7 @@ func (a *App) PrintEnv(w io.Writer, verbose bool) error {
 
 	err := tabWriter.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/cli/filemode/filemode.go
+++ b/internals/cli/filemode/filemode.go
@@ -39,7 +39,7 @@ func Parse(mode string) (FileMode, error) {
 func (m *FileMode) Set(value string) error {
 	fileMode, err := Parse(value)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	*m = fileMode
 	return nil

--- a/internals/cli/io.go
+++ b/internals/cli/io.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // PrettyJSON returns a 4-space indented JSON text.
@@ -11,7 +9,7 @@ import (
 func PrettyJSON(data interface{}) (string, error) {
 	pretty, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	return string(pretty), nil

--- a/internals/cli/mlock/mlock_unix.go
+++ b/internals/cli/mlock/mlock_unix.go
@@ -3,12 +3,9 @@
 package mlock
 
 import (
-	"syscall"
-
-	"github.com/secrethub/secrethub-go/internals/errio"
-
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -49,7 +46,7 @@ func lockMemory() error {
 				"Please try again with root privileges and see if the problem persists.",
 			err)
 	} else if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	log.Debugf("mlock is active")
 	return nil

--- a/internals/cli/ui/ask.go
+++ b/internals/cli/ui/ask.go
@@ -20,12 +20,12 @@ var (
 func Ask(io IO, question string) (string, error) {
 	r, w, err := io.Prompts()
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	_, err = fmt.Fprintf(w, "%s", question)
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 	return Readln(r)
 }
@@ -35,7 +35,7 @@ func Ask(io IO, question string) (string, error) {
 func AskSecret(io IO, question string) (string, error) {
 	promptIn, promptOut, err := io.Prompts()
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	_, err = fmt.Fprintf(promptOut, "%s", question)
@@ -58,12 +58,12 @@ func AskSecret(io IO, question string) (string, error) {
 func AskAndValidate(io IO, question string, n int, validationFunc func(string) error) (string, error) {
 	_, promptOut, err := io.Prompts()
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 	for i := 0; i < n; i++ {
 		response, err := Ask(io, question)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 
 		err = validationFunc(response)
@@ -73,7 +73,7 @@ func AskAndValidate(io IO, question string, n int, validationFunc func(string) e
 
 		fmt.Fprintf(promptOut, "\nInvalid input: %s\nPlease try again.\n", err)
 	}
-	return "", errio.Error(err)
+	return "", err
 }
 
 // ConfirmCaseInsensitive asks the user to confirm by typing one of the expected strings.
@@ -104,13 +104,13 @@ func ConfirmCaseInsensitive(io IO, question string, expected ...string) (bool, e
 func AskPassphrase(io IO, question string, repeatPhrase string, n int) (string, error) {
 	_, promptOut, err := io.Prompts()
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	for i := 0; i < n; i++ {
 		answer, err := AskSecret(io, question)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 
 		if answer == "" {
@@ -119,7 +119,7 @@ func AskPassphrase(io IO, question string, repeatPhrase string, n int) (string, 
 
 		confirmed, err := AskSecret(io, repeatPhrase)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 
 		if answer == confirmed {

--- a/internals/cli/ui/io.go
+++ b/internals/cli/ui/io.go
@@ -3,10 +3,10 @@ package ui
 import (
 	"bufio"
 	"io"
-
 	"os"
 
 	"github.com/secrethub/secrethub-go/internals/errio"
+
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/internals/cli/ui/testing.go
+++ b/internals/cli/ui/testing.go
@@ -4,10 +4,7 @@ package ui
 
 import (
 	"bytes"
-
 	"errors"
-
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // FakeIO is a helper type for testing that implements the ui.IO interface
@@ -65,7 +62,7 @@ type FakeReader struct {
 func (f *FakeReader) ReadPassword() ([]byte, error) {
 	pass, err := Readln(f)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 	return []byte(pass), nil
 }

--- a/internals/secrethub/account_email_verify.go
+++ b/internals/secrethub/account_email_verify.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // AccountEmailVerifyCommand is a command to inspect account details.
@@ -32,12 +31,12 @@ func (cmd *AccountEmailVerifyCommand) Register(r Registerer) {
 func (cmd *AccountEmailVerifyCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	user, err := client.Me().GetUser()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if user.EmailVerified {

--- a/internals/secrethub/account_init.go
+++ b/internals/secrethub/account_init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -71,12 +70,12 @@ func (cmd *AccountInitCommand) Run() error {
 	if !cmd.isContinue {
 		profileDir, err := cmd.credentialStore.NewProfileDir()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		exists, err := cmd.credentialStore.CredentialExists()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		credentialPath := profileDir.CredentialPath()
@@ -108,7 +107,7 @@ func (cmd *AccountInitCommand) Run() error {
 						if err == ui.ErrCannotAsk {
 							return ErrCredentialAlreadyAuthorized(me.PrettyName())
 						} else if err != nil {
-							return errio.Error(err)
+							return err
 						}
 
 						if !confirmed {
@@ -141,7 +140,7 @@ func (cmd *AccountInitCommand) Run() error {
 				if err == ui.ErrCannotAsk {
 					return ErrLocalAccountFound
 				} else if err != nil {
-					return errio.Error(err)
+					return err
 				}
 
 				if !confirmed {
@@ -165,7 +164,7 @@ func (cmd *AccountInitCommand) Run() error {
 		if !cmd.credentialStore.IsPassphraseSet() && !cmd.force {
 			passphrase, err := ui.AskPassphrase(cmd.io, "Please enter a passphrase to protect your local credential (leave empty for no passphrase): ", "Enter the same passphrase again: ", 3)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			cmd.credentialStore.SetPassphrase(passphrase)
 		}
@@ -173,14 +172,14 @@ func (cmd *AccountInitCommand) Run() error {
 		fmt.Fprint(cmd.io.Stdout(), "Generating credential...")
 		credential, err := secrethub.GenerateCredential()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		cmd.credentialStore.Set(credential)
 		fmt.Fprintln(cmd.io.Stdout(), " Done")
 
 		err = cmd.credentialStore.Save()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		verifier, err := credential.Verifier()
@@ -214,7 +213,7 @@ func (cmd *AccountInitCommand) Run() error {
 		if cmd.useClipboard {
 			err = cmd.clipper.WriteAll(out)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			fmt.Fprintln(cmd.io.Stdout(), "The credential's public component has been copied to the clipboard. To add the credential to your account, paste the clipboard contents in https://dashboard.secrethub.io/account-init")
 		} else {

--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // AccountInspectCommand is a command to inspect account details.
@@ -37,17 +36,17 @@ func (cmd *AccountInspectCommand) Register(r Registerer) {
 func (cmd *AccountInspectCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	user, err := client.Users().Me()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	output, err := cli.PrettyJSON(newOutputUser(user, cmd.timeFormatter))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), output)

--- a/internals/secrethub/acl_check.go
+++ b/internals/secrethub/acl_check.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ACLCheckCommand prints the access level(s) on a given directory.
@@ -39,13 +38,13 @@ func (cmd *ACLCheckCommand) Register(r Registerer) {
 func (cmd *ACLCheckCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if cmd.accountName != "" {
 		level, err := client.AccessRules().Get(cmd.path.Value(), cmd.accountName.Value())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintf(cmd.io.Stdout(), "%s\n", level.Permission.String())
@@ -54,7 +53,7 @@ func (cmd *ACLCheckCommand) Run() error {
 
 	levels, err := client.AccessRules().ListLevels(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	sort.Sort(api.SortAccessLevels(levels))
@@ -71,7 +70,7 @@ func (cmd *ACLCheckCommand) Run() error {
 
 	err = tabWriter.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/acl_check_test.go
+++ b/internals/secrethub/acl_check_test.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/assert"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func TestACLCheckCommand_Run(t *testing.T) {
-	testError := errio.Error(errors.New("test error"))
+	testError := errors.New("test error")
 
 	cases := map[string]struct {
 		cmd                  ACLCheckCommand

--- a/internals/secrethub/acl_list.go
+++ b/internals/secrethub/acl_list.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ACLListCommand prints access rules for the given directory.
@@ -56,17 +55,17 @@ func (cmd *ACLListCommand) beforeRun() {
 func (cmd *ACLListCommand) run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	rules, err := client.AccessRules().List(cmd.path.Value(), cmd.depth, cmd.ancestors)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	tree, err := client.Dirs().GetTree(cmd.path.Value(), cmd.depth, cmd.ancestors)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	// Separate all rules into lists of rules per directory.
@@ -81,7 +80,7 @@ func (cmd *ACLListCommand) run() error {
 	for dirID, list := range ruleIDMap {
 		dirPath, err := tree.AbsDirPath(&dirID)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		dirRules := make([]*api.AccessRule, len(list))
@@ -120,7 +119,7 @@ func (cmd *ACLListCommand) run() error {
 
 	err = tabWriter.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/acl_list_test.go
+++ b/internals/secrethub/acl_list_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"github.com/secrethub/secrethub-go/internals/assert"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func TestACLListCommand_run(t *testing.T) {
-	testError := errio.Error(errors.New("test error"))
+	testError := errors.New("test error")
 
 	dir1ID := uuid.New()
 	dir2ID := uuid.New()

--- a/internals/secrethub/acl_rm.go
+++ b/internals/secrethub/acl_rm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ACLRmCommand handles removing an access rule.
@@ -48,7 +47,7 @@ func (cmd *ACLRmCommand) Run() error {
 			ui.DefaultNo,
 		)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if !confirmed {
@@ -59,14 +58,14 @@ func (cmd *ACLRmCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Removing access rule...")
 
 	err = client.AccessRules().Delete(cmd.path.Value(), cmd.accountName.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Removal complete! The access rule for %s on %s has been removed.\n", cmd.accountName, cmd.path)

--- a/internals/secrethub/acl_rm_test.go
+++ b/internals/secrethub/acl_rm_test.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/assert"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func TestACLRmCommand_Run(t *testing.T) {
-	testError := errio.Error(errors.New("test error"))
+	testError := errors.New("test error")
 
 	cases := map[string]struct {
 		cmd            ACLRmCommand

--- a/internals/secrethub/acl_set.go
+++ b/internals/secrethub/acl_set.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ACLSetCommand is a command to set access rules.
@@ -53,7 +52,7 @@ func (cmd *ACLSetCommand) Run() error {
 			ui.DefaultNo,
 		)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if !confirmed {
@@ -66,12 +65,12 @@ func (cmd *ACLSetCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = client.AccessRules().Set(cmd.path.Value(), cmd.permission, cmd.accountName.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Access rule set!")

--- a/internals/secrethub/app.go
+++ b/internals/secrethub/app.go
@@ -89,7 +89,9 @@ func NewApp() *App {
 	store := NewCredentialStore(io)
 	help := "The SecretHub command-line interface is a unified tool to manage your infrastructure secrets with SecretHub.\n\n" +
 		"For a step-by-step introduction, check out:\n\n" +
-		"https://secrethub.io/docs/getting-started/\n\n" +
+		"  https://secrethub.io/docs/getting-started/\n\n" +
+		"To get help, see:\n\n" +
+		"  https://secrethub.io/support/\n\n" +
 		"The CLI is configurable through command-line flags and environment variables. " +
 		"Options set on the command-line take precedence over those set in the environment. " +
 		"The format for environment variables is `SECRETHUB_[COMMAND_]FLAG_NAME`."

--- a/internals/secrethub/audit_helper.go
+++ b/internals/secrethub/audit_helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 func getAuditActor(event *api.Audit) (string, error) {
@@ -39,13 +38,13 @@ func getAuditSubject(event *api.Audit, tree *api.Tree) (string, error) {
 	case api.AuditSubjectSecret:
 		secretPath, err := tree.AbsSecretPath(event.Subject.Secret.SecretID)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 		return secretPath.String(), nil
 	case api.AuditSubjectSecretVersion:
 		secretPath, err := tree.AbsSecretPath(event.Subject.SecretVersion.Secret.SecretID)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 		return fmt.Sprintf("%s:%d", secretPath.String(), event.Subject.SecretVersion.Version), nil
 	case api.AuditSubjectSecretKey:

--- a/internals/secrethub/audit_repo.go
+++ b/internals/secrethub/audit_repo.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // AuditRepoCommand prints all audit events for a given repository.
@@ -51,17 +50,17 @@ func (cmd *AuditRepoCommand) beforeRun() {
 func (cmd *AuditRepoCommand) run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	events, err := client.Repos().ListEvents(cmd.path.Value(), nil)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	dirFS, err := client.Dirs().GetTree(cmd.path.GetDirPath().Value(), -1, false)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	tabWriter := tabwriter.NewWriter(cmd.io.Stdout(), 0, 4, 4, ' ', 0)
@@ -74,12 +73,12 @@ func (cmd *AuditRepoCommand) run() error {
 
 		actor, err := getAuditActor(event)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		subject, err := getAuditSubject(event, dirFS)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\t%s\n",
@@ -93,7 +92,7 @@ func (cmd *AuditRepoCommand) run() error {
 
 	err = tabWriter.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/audit_repo_test.go
+++ b/internals/secrethub/audit_repo_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/assert"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func TestAuditRepoCommand_run(t *testing.T) {
-	testError := errio.Error(errors.New("test error"))
+	testError := errors.New("test error")
 
 	cases := map[string]struct {
 		cmd AuditRepoCommand

--- a/internals/secrethub/audit_secret.go
+++ b/internals/secrethub/audit_secret.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // AuditSecretCommand prints all audit events for a given secret.
@@ -56,7 +55,7 @@ func (cmd *AuditSecretCommand) run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	events, err := client.Secrets().ListEvents(cmd.path.Value(), nil)
@@ -70,7 +69,7 @@ func (cmd *AuditSecretCommand) run() error {
 	}
 
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	tabWriter := tabwriter.NewWriter(cmd.io.Stdout(), 0, 4, 4, ' ', 0)
@@ -83,7 +82,7 @@ func (cmd *AuditSecretCommand) run() error {
 
 		actor, err := getAuditActor(event)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\n",
@@ -96,7 +95,7 @@ func (cmd *AuditSecretCommand) run() error {
 
 	err = tabWriter.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/audit_secret_test.go
+++ b/internals/secrethub/audit_secret_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/assert"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func TestAuditSecretCommand_run(t *testing.T) {
-	testError := errio.Error(errors.New("test error"))
+	testError := errors.New("test error")
 
 	cases := map[string]struct {
 		cmd AuditSecretCommand

--- a/internals/secrethub/clear.go
+++ b/internals/secrethub/clear.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-cli/internals/secretspec"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ClearCommand clears the secrets from the system.
@@ -35,7 +34,7 @@ func (cmd *ClearCommand) Register(r Registerer) {
 func (cmd *ClearCommand) Run() error {
 	presenter, err := secretspec.NewPresenter("", true, secretspec.DefaultParsers...)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = os.Stat(cmd.in)
@@ -50,14 +49,14 @@ func (cmd *ClearCommand) Run() error {
 
 	err = presenter.Parse(spec)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Clearing secrets...")
 
 	err = presenter.Clear()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Clear complete! The secrets are no longer available on the system.\n")

--- a/internals/secrethub/clear_clipboard.go
+++ b/internals/secrethub/clear_clipboard.go
@@ -7,8 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/clip"
 	"github.com/secrethub/secrethub-cli/internals/cli/cloneproc"
 
-	"github.com/secrethub/secrethub-go/internals/errio"
-
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -56,7 +54,7 @@ func (cmd *ClearClipboardCommand) Run() error {
 
 	err = cmd.clipper.WriteAll(nil)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	return nil
 }
@@ -65,12 +63,12 @@ func (cmd *ClearClipboardCommand) Run() error {
 func WriteClipboardAutoClear(data []byte, timeout time.Duration, clipper clip.Clipper) error {
 	hash, err := bcrypt.GenerateFromPassword(data, bcrypt.DefaultCost)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	err = clipper.WriteAll(data)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	err = cloneproc.Spawn(

--- a/internals/secrethub/client_factory.go
+++ b/internals/secrethub/client_factory.go
@@ -3,7 +3,6 @@ package secrethub
 import (
 	"net/url"
 
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -38,7 +37,7 @@ func (f *clientFactory) NewClient() (secrethub.Client, error) {
 	if f.client == nil {
 		credential, err := f.store.Get()
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 
 		f.client = secrethub.NewClient(credential, f.NewClientOptions())

--- a/internals/secrethub/color.go
+++ b/internals/secrethub/color.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // noColorFlag configures the global behaviour to disable colored output.
@@ -30,7 +29,7 @@ func (f noColorFlag) String() string {
 func (f *noColorFlag) Set(value string) error {
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	*f = noColorFlag(b)
 	f.init()

--- a/internals/secrethub/config.go
+++ b/internals/secrethub/config.go
@@ -127,12 +127,12 @@ func newUserConfig(username, keyPath string, remoteURL *url.URL) (*Config, error
 	// Replace ~/ with the home directory
 	keyPathExpanded, err := homedir.Expand(keyPath)
 	if err != nil {
-		return &config, errio.Error(err)
+		return &config, err
 	}
 
 	absKeyPath, err := filepath.Abs(keyPathExpanded)
 	if err != nil {
-		return &config, errio.Error(err)
+		return &config, err
 	}
 
 	config.Type = ConfigUserType
@@ -151,7 +151,7 @@ func parseUserConfig(io ui.IO, mapConfig configuration.ConfigMap, path string) (
 
 	currentVersion, err := mapConfig.GetVersion()
 	if err != nil {
-		return config, errio.Error(err)
+		return config, err
 	}
 
 	updated := false
@@ -261,7 +261,7 @@ func LoadConfig(io ui.IO, path string) (*Config, error) {
 
 	t, err := mapConfig.GetType()
 	if err != nil {
-		return &config, errio.Error(err)
+		return &config, err
 	}
 
 	if t == ConfigUserType {

--- a/internals/secrethub/config_upgrade.go
+++ b/internals/secrethub/config_upgrade.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // ConfigCommand handles operations on the SecretHub configuration.
@@ -53,7 +52,7 @@ func (cmd *ConfigUpgradeCommand) Register(r Registerer) {
 func (cmd *ConfigUpgradeCommand) Run() error {
 	profileDir, err := cmd.credentialStore.NewProfileDir()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	// Run command
@@ -67,7 +66,7 @@ func (cmd *ConfigUpgradeCommand) Run() error {
 		ui.DefaultNo,
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if !confirmed {
@@ -82,7 +81,7 @@ func (cmd *ConfigUpgradeCommand) Run() error {
 
 		config, err := LoadConfig(cmd.io, profileDir.oldConfigFile())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if config.Type == ConfigUserType {
@@ -92,26 +91,26 @@ func (cmd *ConfigUpgradeCommand) Run() error {
 
 	credential, err := cmd.credentialStore.Get()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	passphrase, err := ui.AskPassphrase(cmd.io, "Please enter a passphrase to (re)encrypt your local credential (leave empty for no passphrase): ", "Enter the same passphrase again: ", 3)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	cmd.credentialStore.SetPassphrase(passphrase)
 	cmd.credentialStore.Set(credential)
 	err = cmd.credentialStore.Save()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	// Remove old files
 	for _, file := range cleanupFiles {
 		err = os.Remove(file)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -8,7 +8,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/posix"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -81,7 +80,7 @@ func (store *credentialStore) Set(credential secrethub.Credential) {
 func (store *credentialStore) CredentialExists() (bool, error) {
 	profileDir, err := store.NewProfileDir()
 	if err != nil {
-		return false, errio.Error(err)
+		return false, err
 	}
 	credentialPath := profileDir.CredentialPath()
 	_, err = os.Stat(credentialPath)
@@ -91,7 +90,7 @@ func (store *credentialStore) CredentialExists() (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	}
-	return false, errio.Error(err)
+	return false, err
 }
 
 // Get retrieves a credential from the store.
@@ -104,7 +103,7 @@ func (store *credentialStore) Get() (secrethub.Credential, error) {
 
 	profileDir, err := store.NewProfileDir()
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 	return NewCredentialReader(store.io, profileDir, store.AccountCredential, store.newPassphraseReader()).Read()
 }
@@ -114,17 +113,17 @@ func (store *credentialStore) Get() (secrethub.Credential, error) {
 func (store *credentialStore) Save() error {
 	profileDir, err := store.NewProfileDir()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	err = os.MkdirAll(profileDir.String(), profileDir.FileMode())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	encoded, err := store.encodeCredential(store.credential, store.credentialPassphrase)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	err = ioutil.WriteFile(profileDir.CredentialPath(), posix.AddNewLine([]byte(encoded)), profileDir.CredentialFileMode())
@@ -139,7 +138,7 @@ func (store *credentialStore) encodeCredential(credential secrethub.Credential, 
 	if passphrase != "" {
 		armorer, err := secrethub.NewPassBasedKey([]byte(passphrase))
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 		return secrethub.EncodeEncryptedCredential(credential, armorer)
 

--- a/internals/secrethub/debug.go
+++ b/internals/secrethub/debug.go
@@ -4,8 +4,6 @@ import (
 	"strconv"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
-
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RegisterDebugFlag registers a debug flag that changes the log level of the given logger to DEBUG.
@@ -37,7 +35,7 @@ func (f debugFlag) String() string {
 func (f *debugFlag) Set(value string) error {
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	f.debug = b
 	f.init()

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -70,19 +70,19 @@ func (cmd *GenerateSecretCommand) run() error {
 
 	data, err := cmd.generator.Generate(cmd.length)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprint(cmd.io.Stdout(), "Writing secret value...\n")
 
 	version, err := client.Secrets().Write(cmd.path.Value(), data)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Write complete! A randomly generated secret has been written to %s:%d.\n", cmd.path, version.Version)

--- a/internals/secrethub/inject.go
+++ b/internals/secrethub/inject.go
@@ -14,8 +14,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-cli/internals/cli/validation"
 
-	"github.com/secrethub/secrethub-go/internals/errio"
-
 	"github.com/docker/go-units"
 )
 
@@ -94,7 +92,7 @@ func (cmd *InjectCommand) Run() error {
 
 		raw, err = ioutil.ReadAll(cmd.io.Stdin())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -102,7 +100,7 @@ func (cmd *InjectCommand) Run() error {
 
 	osEnv, err := parseKeyValueStringsToMap(os.Environ())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	for k, v := range osEnv {
@@ -129,19 +127,19 @@ func (cmd *InjectCommand) Run() error {
 
 	template, err := parser.Parse(string(raw), 1, 1)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	injected, err := template.Evaluate(templateVars, newSecretReader(cmd.newClient))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	out := []byte(injected)
 	if cmd.useClipboard {
 		err = WriteClipboardAutoClear(out, cmd.clearClipboardAfter, cmd.clipper)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintln(cmd.io.Stdout(), fmt.Sprintf("Copied injected template to clipboard. It will be cleared after %s.", units.HumanDuration(cmd.clearClipboardAfter)))
@@ -161,7 +159,7 @@ func (cmd *InjectCommand) Run() error {
 				ui.DefaultNo,
 			)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			if !confirmed {

--- a/internals/secrethub/inspect_secret.go
+++ b/internals/secrethub/inspect_secret.go
@@ -7,7 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // InspectSecretCommand prints out a secret's details.
@@ -32,22 +31,22 @@ func NewInspectSecretCommand(path api.SecretPath, io ui.IO, newClient newClientF
 func (cmd *InspectSecretCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	secret, err := client.Secrets().Versions().GetWithoutData(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	versions, err := client.Secrets().Versions().ListWithoutData(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	output, err := cli.PrettyJSON(newSecretOutput(secret.Secret, versions, cmd.timeFormatter))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), output)

--- a/internals/secrethub/inspect_secret_version.go
+++ b/internals/secrethub/inspect_secret_version.go
@@ -7,7 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // InspectSecretVersionCommand prints out the details of a secret version in JSON format.
@@ -32,17 +31,17 @@ func NewInspectSecretVersionCommand(path api.SecretPath, io ui.IO, newClient new
 func (cmd *InspectSecretVersionCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	version, err := client.Secrets().Versions().GetWithoutData(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	output, err := cli.PrettyJSON(newSecretVersionOutput(version, cmd.timeFormatter))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), output)

--- a/internals/secrethub/keyring.go
+++ b/internals/secrethub/keyring.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/cloneproc"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	libkeyring "github.com/zalando/go-keyring"
 )
 
@@ -75,7 +74,7 @@ func (pr passphraseReader) Get(username string) ([]byte, error) {
 	if pr.Cache.IsEnabled() {
 		passphrase, err := pr.Cache.Get(username)
 		if err != nil && err != ErrKeyringItemNotFound {
-			return nil, errio.Error(err)
+			return nil, err
 		} else if err == nil {
 			return []byte(passphrase), nil
 		}
@@ -85,13 +84,13 @@ func (pr passphraseReader) Get(username string) ([]byte, error) {
 	if err == ui.ErrCannotAsk {
 		return nil, ErrPassphraseFlagNotSet // if we cannot ask, users should use the --passphrase flag
 	} else if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	if pr.Cache.IsEnabled() {
 		err := pr.Cache.Set(username, passphrase)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 	}
 
@@ -143,7 +142,7 @@ func (c PassphraseCache) Set(username, passphrase string) error {
 	if !item.RunningCleanupProcess {
 		err = c.cleaner.Cleanup(username)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -171,7 +170,7 @@ func (c PassphraseCache) Get(username string) (string, error) {
 	if !item.RunningCleanupProcess {
 		err = c.cleaner.Cleanup(username)
 		if err != nil {
-			return "", errio.Error(err)
+			return "", err
 		}
 	}
 
@@ -179,7 +178,7 @@ func (c PassphraseCache) Get(username string) (string, error) {
 
 	err = c.keyring.Set(username, item)
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	return item.Passphrase, nil

--- a/internals/secrethub/list.go
+++ b/internals/secrethub/list.go
@@ -59,7 +59,7 @@ func (cmd *LsCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	// It must be a SecretPath as only SecretPaths has versions.
@@ -67,17 +67,17 @@ func (cmd *LsCommand) Run() error {
 		secretPath, err := cmd.path.ToSecretPath()
 		if err != nil {
 			fmt.Println("no secret path!")
-			return errio.Error(err)
+			return err
 		}
 
 		version, err := client.Secrets().Versions().GetWithoutData(secretPath.Value())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		err = printVersions(cmd.io.Stdout(), cmd.quiet, timeFormatter, version)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		return nil
@@ -88,13 +88,13 @@ func (cmd *LsCommand) Run() error {
 	if err == nil {
 		dirFS, err := client.Dirs().GetTree(dirPath.Value(), 1, false)
 		if err == api.ErrDirNotFound && dirPath.IsRepoPath() {
-			return errio.Error(err)
+			return err
 		} else if err != nil && err != api.ErrDirNotFound {
-			return errio.Error(err)
+			return err
 		} else if err == nil {
 			err = printDir(cmd.io.Stdout(), cmd.quiet, dirFS.RootDir, timeFormatter)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			return nil
 		}
@@ -107,12 +107,12 @@ func (cmd *LsCommand) Run() error {
 		if err == api.ErrSecretNotFound {
 			return ErrResourceNotFound(cmd.path)
 		} else if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		err = printVersions(cmd.io.Stdout(), cmd.quiet, timeFormatter, versions...)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		return nil
@@ -142,7 +142,7 @@ func printVersions(w io.Writer, quiet bool, timeFormatter TimeFormatter, version
 		}
 		err := w.Flush()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 	return nil
@@ -171,7 +171,7 @@ func printDir(w io.Writer, quiet bool, dir *api.Dir, timeFormatter TimeFormatter
 		}
 		err := tw.Flush()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 	return nil

--- a/internals/secrethub/mkdir.go
+++ b/internals/secrethub/mkdir.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // Errors
@@ -44,12 +43,12 @@ func (cmd *MkDirCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = client.Dirs().Create(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Created a new directory at %s\n", cmd.path)

--- a/internals/secrethub/mlock.go
+++ b/internals/secrethub/mlock.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/mlock"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // mlockFlag configures locking memory.
@@ -16,7 +15,7 @@ func (f mlockFlag) init() error {
 		if mlock.Supported() {
 			err := mlock.LockMemory()
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 		}
 	}
@@ -38,7 +37,7 @@ func (f mlockFlag) String() string {
 func (f *mlockFlag) Set(value string) error {
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	*f = mlockFlag(b)
 	return f.init()

--- a/internals/secrethub/org_init.go
+++ b/internals/secrethub/org_init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgInitCommand handles creating an organization.
@@ -42,7 +41,7 @@ func (cmd *OrgInitCommand) Run() error {
 	if !cmd.force {
 		confirmed, err := ui.AskYesNo(cmd.io, "Creating an organization will start a free 14-day trial (no strings attached) of the Team plan. Visit https://secrethub.io/pricing for more information. Would you like to proceed?", ui.DefaultYes)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		if !confirmed {
 			fmt.Fprintln(cmd.io.Stdout(), "Aborting.")
@@ -66,7 +65,7 @@ func (cmd *OrgInitCommand) Run() error {
 		if cmd.name == "" {
 			name, err := ui.AskAndValidate(cmd.io, "The name you would like to use for your organization: ", 2, api.ValidateOrgName)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			cmd.name = api.OrgName(name)
 		}
@@ -74,7 +73,7 @@ func (cmd *OrgInitCommand) Run() error {
 		if cmd.description == "" {
 			cmd.description, err = ui.AskAndValidate(cmd.io, "A short description so your teammates will recognize the organization (max. 144 chars): ", 2, api.ValidateOrgDescription)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 		}
 
@@ -84,14 +83,14 @@ func (cmd *OrgInitCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Creating organization...\n")
 
 	resp, err := client.Orgs().Create(cmd.name.Value(), cmd.description)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Creation complete! The organization %s is now ready to use.\n", resp.Name)

--- a/internals/secrethub/org_inspect.go
+++ b/internals/secrethub/org_inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgInspectCommand handles printing out the details of an organization in a JSON format.
@@ -39,27 +38,27 @@ func (cmd *OrgInspectCommand) Register(r Registerer) {
 func (cmd *OrgInspectCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	org, err := client.Orgs().Get(cmd.name.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	members, err := client.Orgs().Members().List(cmd.name.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	repos, err := client.Repos().List(cmd.name.Namespace().Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	output, err := cli.PrettyJSON(newOrgInspectOutput(org, members, repos, cmd.timeFormatter))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), output)

--- a/internals/secrethub/org_invite.go
+++ b/internals/secrethub/org_invite.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgInviteCommand handles inviting a user to an organization.
@@ -46,7 +45,7 @@ func (cmd *OrgInviteCommand) Run() error {
 
 		confirmed, err := ui.AskYesNo(cmd.io, msg, ui.DefaultNo)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if !confirmed {
@@ -57,14 +56,14 @@ func (cmd *OrgInviteCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Inviting user...")
 
 	resp, err := client.Orgs().Members().Invite(cmd.orgName.Value(), cmd.username, cmd.role)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Invite complete! The user %s is now %s of the %s organization.\n", resp.User.Username, resp.Role, cmd.orgName)

--- a/internals/secrethub/org_list_users.go
+++ b/internals/secrethub/org_list_users.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgListUsersCommand handles listing the users of an organization.
@@ -51,12 +50,12 @@ func (cmd *OrgListUsersCommand) beforeRun() {
 func (cmd *OrgListUsersCommand) run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	resp, err := client.Orgs().Members().List(cmd.orgName.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	sort.Sort(api.SortOrgMemberByUsername(resp))
@@ -70,7 +69,7 @@ func (cmd *OrgListUsersCommand) run() error {
 
 	err = w.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/org_ls.go
+++ b/internals/secrethub/org_ls.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgLsCommand handles listing all organisations a user is a member of.
@@ -51,12 +50,12 @@ func (cmd *OrgLsCommand) beforeRun() {
 func (cmd *OrgLsCommand) run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	resp, err := client.Orgs().ListMine()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	sort.Sort(api.SortOrgByName(resp))
@@ -74,12 +73,12 @@ func (cmd *OrgLsCommand) run() error {
 			// TODO SHDEV-724: refactor these two calls to include the counts in the api.Org response by default.
 			members, err := client.Orgs().Members().List(org.Name)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			repos, err := client.Repos().List(org.Name)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			fmt.Fprintf(w, "%s\t%d\t%d\t%s\n", org.Name, len(repos), len(members), cmd.timeFormatter.Format(org.CreatedAt.Local()))
@@ -87,7 +86,7 @@ func (cmd *OrgLsCommand) run() error {
 
 		err = w.Flush()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 

--- a/internals/secrethub/org_revoke.go
+++ b/internals/secrethub/org_revoke.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgRevokeCommand handles revoking a member from an organization.
@@ -40,7 +39,7 @@ func (cmd *OrgRevokeCommand) Register(r Registerer) {
 func (cmd *OrgRevokeCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	opts := &api.RevokeOpts{
@@ -48,7 +47,7 @@ func (cmd *OrgRevokeCommand) Run() error {
 	}
 	planned, err := client.Orgs().Members().Revoke(cmd.orgName.Value(), cmd.username, opts)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if len(planned.Repos) > 0 {
@@ -67,7 +66,7 @@ func (cmd *OrgRevokeCommand) Run() error {
 
 		err = writeOrgRevokeRepoList(cmd.io.Stdout(), planned.Repos...)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		flagged := planned.StatusCounts[api.StatusFlagged]
@@ -102,14 +101,14 @@ func (cmd *OrgRevokeCommand) Run() error {
 
 	revoked, err := client.Orgs().Members().Revoke(cmd.orgName.Value(), cmd.username, nil)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if len(revoked.Repos) > 0 {
 		fmt.Fprintln(cmd.io.Stdout(), "")
 		err = writeOrgRevokeRepoList(cmd.io.Stdout(), revoked.Repos...)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		flagged := revoked.StatusCounts[api.StatusFlagged]
@@ -138,7 +137,7 @@ func writeOrgRevokeRepoList(w io.Writer, repos ...*api.RevokeRepoResponse) error
 	}
 	err := tw.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	fmt.Fprintln(w, "")
 	return nil

--- a/internals/secrethub/org_rm.go
+++ b/internals/secrethub/org_rm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgRmCommand deletes an organization, prompting the user for confirmation.
@@ -55,14 +54,14 @@ func (cmd *OrgRmCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Deleting organization...")
 
 	err = client.Orgs().Delete(cmd.name.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Delete complete! The organization %s has been permanently deleted.\n", cmd.name)

--- a/internals/secrethub/org_set_role.go
+++ b/internals/secrethub/org_set_role.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // OrgSetRoleCommand handles updating the role of an organization member.
@@ -39,14 +38,14 @@ func (cmd *OrgSetRoleCommand) Register(r Registerer) {
 func (cmd *OrgSetRoleCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Setting role...\n")
 
 	resp, err := client.Orgs().Members().Update(cmd.orgName.Value(), cmd.username, cmd.role)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Set complete! The user %s is %s of the %s organization.\n", resp.User.Username, resp.Role, cmd.orgName)

--- a/internals/secrethub/printenv.go
+++ b/internals/secrethub/printenv.go
@@ -3,8 +3,6 @@ package secrethub
 import (
 	"github.com/secrethub/secrethub-cli/internals/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // PrintEnvCommand prints out debug statements about all environment variables.
@@ -26,7 +24,7 @@ func NewPrintEnvCommand(app *cli.App, io ui.IO) *PrintEnvCommand {
 func (cmd *PrintEnvCommand) Run() error {
 	err := cmd.app.PrintEnv(cmd.io.Stdout(), cmd.verbose)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	return nil
 }

--- a/internals/secrethub/read.go
+++ b/internals/secrethub/read.go
@@ -9,7 +9,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 
 	units "github.com/docker/go-units"
 )
@@ -53,18 +52,18 @@ func (cmd *ReadCommand) Register(r Registerer) {
 func (cmd *ReadCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	secret, err := client.Secrets().Versions().GetWithData(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if cmd.useClipboard {
 		err = WriteClipboardAutoClear(secret.Data, cmd.clearClipboardAfter, cmd.clipper)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintf(

--- a/internals/secrethub/repo_export.go
+++ b/internals/secrethub/repo_export.go
@@ -11,7 +11,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // Error
@@ -67,7 +66,7 @@ func (cmd *RepoExportCommand) Run() error {
 		cmd.path.String(),
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if !confirmed {
@@ -77,17 +76,17 @@ func (cmd *RepoExportCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	rootDir, err := client.Dirs().GetTree(cmd.path.GetDirPath().Value(), -1, false)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	zipFile, err := os.Create(cmd.zipName)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	writer := zip.NewWriter(zipFile)
@@ -106,18 +105,18 @@ func (cmd *RepoExportCommand) Run() error {
 	for _, secret := range rootDir.Secrets {
 		secretPath, err := rootDir.AbsSecretPath(secret.SecretID)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		versions, err := client.Secrets().Versions().ListWithData(secretPath.Value())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		for _, version := range versions {
 			versionPath, err := secretPath.AddVersion(version.Version)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			// Replace the : for / to create a directory for every secret containing versions.
@@ -127,12 +126,12 @@ func (cmd *RepoExportCommand) Run() error {
 
 			zipNode, err := writer.Create(zipSecretPath)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			_, err = zipNode.Write(posix.AddNewLine(version.Data))
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 		}
 	}

--- a/internals/secrethub/repo_init.go
+++ b/internals/secrethub/repo_init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoInitCommand handles creating new repositories.
@@ -35,14 +34,14 @@ func (cmd *RepoInitCommand) Register(r Registerer) {
 func (cmd *RepoInitCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Creating repository...")
 
 	_, err = client.Repos().Create(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Create complete! The repository %s is now ready to use.\n", cmd.path.String())

--- a/internals/secrethub/repo_inspect.go
+++ b/internals/secrethub/repo_inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoInspectCommand handles printing out the details of a repo in a JSON format.
@@ -39,27 +38,27 @@ func (cmd *RepoInspectCommand) Register(r Registerer) {
 func (cmd *RepoInspectCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	repo, err := client.Repos().Get(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	users, err := client.Repos().Users().List(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	services, err := client.Repos().Services().List(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	output, err := cli.PrettyJSON(newInspectRepoOutput(repo, users, services, cmd.timeFormatter))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), output)

--- a/internals/secrethub/repo_invite.go
+++ b/internals/secrethub/repo_invite.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoInviteCommand handles inviting a user to collaborate on a repository.
@@ -39,12 +38,12 @@ func (cmd *RepoInviteCommand) Register(r Registerer) {
 func (cmd *RepoInviteCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	user, err := client.Users().Get(cmd.username)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if !cmd.force {
@@ -54,7 +53,7 @@ func (cmd *RepoInviteCommand) Run() error {
 
 		confirmed, err := ui.AskYesNo(cmd.io, msg, ui.DefaultNo)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if !confirmed {
@@ -66,7 +65,7 @@ func (cmd *RepoInviteCommand) Run() error {
 
 	_, err = client.Repos().Users().Invite(cmd.path.Value(), cmd.username)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Invite complete! The user %s is now a member of the %s repository.\n", user.Username, cmd.path)

--- a/internals/secrethub/repo_ls.go
+++ b/internals/secrethub/repo_ls.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoLSCommand lists repositories.
@@ -51,12 +50,12 @@ func (cmd *RepoLSCommand) beforeRun() {
 func (cmd *RepoLSCommand) run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	list, err := client.Repos().ListMine()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	sort.Sort(api.SortRepoByName(list))
@@ -73,7 +72,7 @@ func (cmd *RepoLSCommand) run() error {
 		}
 		err = w.Flush()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 

--- a/internals/secrethub/repo_revoke.go
+++ b/internals/secrethub/repo_revoke.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoRevokeCommand handles revoking an account access to a repository.
@@ -41,14 +40,14 @@ func (cmd *RepoRevokeCommand) Register(r Registerer) {
 func (cmd *RepoRevokeCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	var prettyName string
 	if cmd.accountName.IsUser() {
 		user, err := client.Users().Get(string(cmd.accountName))
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		prettyName = user.PrettyName()
 	} else {
@@ -65,7 +64,7 @@ func (cmd *RepoRevokeCommand) Run() error {
 		if err == ui.ErrCannotAsk {
 			return ErrCannotDoWithoutForce
 		} else if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if !confirmed {
@@ -83,7 +82,7 @@ func (cmd *RepoRevokeCommand) Run() error {
 		revoked, err = client.Repos().Users().Revoke(cmd.path.Value(), string(cmd.accountName))
 	}
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if revoked.Status == api.StatusFailed {
@@ -97,7 +96,7 @@ func (cmd *RepoRevokeCommand) Run() error {
 
 	rootDir, err := client.Dirs().GetTree(cmd.path.GetDirPath().Value(), -1, false)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	w := tabwriter.NewWriter(cmd.io.Stdout(), 0, 2, 2, ' ', 0)
@@ -106,7 +105,7 @@ func (cmd *RepoRevokeCommand) Run() error {
 
 	err = w.Flush()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if countFlagged > 0 {

--- a/internals/secrethub/repo_rm.go
+++ b/internals/secrethub/repo_rm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // RepoRmCommand handles removing a repo.
@@ -35,12 +34,12 @@ func (cmd *RepoRmCommand) Register(r Registerer) {
 func (cmd *RepoRmCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = client.Repos().Get(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	confirmed, err := ui.ConfirmCaseInsensitive(
@@ -54,7 +53,7 @@ func (cmd *RepoRmCommand) Run() error {
 		cmd.path.String(),
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if !confirmed {
@@ -66,7 +65,7 @@ func (cmd *RepoRmCommand) Run() error {
 
 	err = client.Repos().Delete(cmd.path.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(cmd.io.Stdout(), "Removal complete! The repository %s has been permanently removed.\n", cmd.path)

--- a/internals/secrethub/rm.go
+++ b/internals/secrethub/rm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -50,13 +49,13 @@ func (cmd *RmCommand) Register(r Registerer) {
 func (cmd *RmCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if !cmd.path.HasVersion() {
 		dirPath, err := cmd.path.ToDirPath()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		if dirPath.IsRepoPath() {
@@ -70,13 +69,13 @@ func (cmd *RmCommand) Run() error {
 			}
 			return rmDir(client, dirPath, cmd.force, cmd.io)
 		} else if err != api.ErrDirNotFound {
-			return errio.Error(err)
+			return err
 		}
 	}
 
 	secretPath, err := cmd.path.ToSecretPath()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if cmd.path.HasVersion() {
@@ -95,7 +94,7 @@ func (cmd *RmCommand) Run() error {
 func rmSecretVersion(client secrethub.Client, secretPath api.SecretPath, force bool, io ui.IO) error {
 	version, err := secretPath.GetVersion()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	ok, err := askRmConfirmation(
@@ -107,7 +106,7 @@ func rmSecretVersion(client secrethub.Client, secretPath api.SecretPath, force b
 		secretPath.String(),
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	if !ok {
 		return nil
@@ -115,7 +114,7 @@ func rmSecretVersion(client secrethub.Client, secretPath api.SecretPath, force b
 
 	err = client.Secrets().Versions().Delete(secretPath.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(
@@ -137,7 +136,7 @@ func rmSecret(client secrethub.Client, secretPath api.SecretPath, force bool, io
 		secretPath.String(),
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	if !ok {
 		return nil
@@ -145,7 +144,7 @@ func rmSecret(client secrethub.Client, secretPath api.SecretPath, force bool, io
 
 	err = client.Secrets().Delete(secretPath.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(
@@ -167,7 +166,7 @@ func rmDir(client secrethub.Client, dirPath api.DirPath, force bool, io ui.IO) e
 		dirPath.String(),
 	)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	if !ok {
 		return nil
@@ -175,7 +174,7 @@ func rmDir(client secrethub.Client, dirPath api.DirPath, force bool, io ui.IO) e
 
 	err = client.Dirs().Delete(dirPath.Value())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintf(

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -97,7 +97,7 @@ func (cmd *RunCommand) Run() error {
 	// TODO: Validate the flags when parsing by implementing the Flag interface for EnvFlags.
 	flagSource, err := NewEnvFlags(cmd.envar)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	envSources = append(envSources, flagSource)
 
@@ -115,7 +115,7 @@ func (cmd *RunCommand) Run() error {
 
 	osEnv, err := parseKeyValueStringsToMap(os.Environ())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	templateVars := make(map[string]string)
@@ -160,7 +160,7 @@ func (cmd *RunCommand) Run() error {
 	if err == nil {
 		dirSource, err := NewEnvDir(envDir)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		envSources = append(envSources, dirSource)
 	}
@@ -175,13 +175,13 @@ func (cmd *RunCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	for path := range secrets {
 		secret, err := client.Secrets().Versions().GetWithData(path)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		secrets[path] = string(secret.Data)
 	}
@@ -193,7 +193,7 @@ func (cmd *RunCommand) Run() error {
 	for _, source := range envSources {
 		pairs, err := source.Env(secrets, secretReader)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		for key, value := range pairs {
@@ -299,7 +299,7 @@ func (cmd *RunCommand) Run() error {
 			}
 
 		}
-		return errio.Error(commandErr)
+		return commandErr
 	}
 
 	return nil
@@ -332,7 +332,7 @@ func parseKeyValueStringsToMap(values []string) (map[string]string, error) {
 
 		err := validation.ValidateEnvarName(key)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 
 		result[key] = value
@@ -668,7 +668,7 @@ func NewEnvFlags(flags map[string]string) (EnvFlags, error) {
 	for name, path := range flags {
 		err := validation.ValidateEnvarName(name)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 
 		err = api.ValidateSecretPath(path)

--- a/internals/secrethub/service_deploy_winrm.go
+++ b/internals/secrethub/service_deploy_winrm.go
@@ -80,7 +80,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 	if cmd.resourceURI.Port() != "" {
 		port, err = strconv.Atoi(cmd.resourceURI.Port())
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -104,7 +104,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 	// check the schema
 	https, err := cmd.checkWinRMTLS()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	skipVerifyCert := cmd.checkWinRMVerifyCert()
@@ -127,20 +127,20 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 		if cmd.username == "" {
 			cmd.username, err = ui.Ask(cmd.io, "What username do you want to use to connect?\n")
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 		}
 
 		if cmd.password == "" {
 			cmd.password, err = ui.AskSecret(cmd.io, fmt.Sprintf("What is the password for user %s?\n", cmd.username))
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 		}
 
 		client, err = winrm.NewBasicClient(config, cmd.username, cmd.password)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	case "cert":
 		var clientCert, clientKey []byte
@@ -160,7 +160,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 
 		client, err = winrm.NewCertClient(config, clientCert, clientKey)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	default:
 		return ErrUnknownAuthType
@@ -171,7 +171,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 	if https {
 		err := client.GetServerCert(cmd.io)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -186,14 +186,14 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 
 	credential, err := ioutil.ReadAll(cmd.io.Stdin())
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	// Copy the config to the host.
 	fmt.Fprintln(cmd.io.Stdout(), "Deploying configuration...")
 	err = deployer.configure(credential)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Deploy complete! The service account can now be used to connect to SecretHub from the host.")
@@ -258,7 +258,7 @@ func (wd windowsDeployer) configure(token []byte) error {
 
 	err := wd.conn.CopyFile(r, wd.path, copyProgress)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -56,22 +55,22 @@ func (cmd *ServiceInitCommand) Run() error {
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	serviceCredential, err := secrethub.GenerateCredential()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	encoded, err := secrethub.EncodeCredential(serviceCredential)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	service, err := client.Services().Create(repo.Value(), cmd.description, serviceCredential)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	if cmd.permission != 0 {
@@ -80,10 +79,10 @@ func (cmd *ServiceInitCommand) Run() error {
 			_, delErr := client.Services().Delete(service.ServiceID)
 			if delErr != nil {
 				fmt.Fprintf(cmd.io.Stdout(), "Failed to cleanup after creating an access rule for %s failed. Be sure to manually remove the created service account %s: %s\n", service.ServiceID, service.ServiceID, err)
-				return errio.Error(delErr)
+				return delErr
 			}
 
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -91,7 +90,7 @@ func (cmd *ServiceInitCommand) Run() error {
 	if cmd.clip {
 		err = WriteClipboardAutoClear(out, defaultClearClipboardAfter, cmd.clipper)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		fmt.Fprintf(cmd.io.Stdout(), "Copied account configuration for %s to clipboard. It will be cleared after 45 seconds.\n", service.ServiceID)

--- a/internals/secrethub/set.go
+++ b/internals/secrethub/set.go
@@ -8,7 +8,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-cli/internals/secretspec"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // Errors
@@ -46,7 +45,7 @@ func (cmd *SetCommand) Register(r Registerer) {
 func (cmd *SetCommand) Run() error {
 	presenter, err := secretspec.NewPresenter("", true, secretspec.DefaultParsers...)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = os.Stat(cmd.in)
@@ -61,12 +60,12 @@ func (cmd *SetCommand) Run() error {
 
 	err = presenter.Parse(spec)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	paths := presenter.Sources()
@@ -82,7 +81,7 @@ func (cmd *SetCommand) Run() error {
 	for path := range paths {
 		secret, err := client.Secrets().Versions().GetWithData(path)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		secrets[path] = *secret
 	}
@@ -91,7 +90,7 @@ func (cmd *SetCommand) Run() error {
 
 	err = presenter.Set(secrets)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Set complete! The secrets are now available on your system.")

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/secrethub"
 )
 
@@ -55,7 +54,7 @@ func (cmd *SignUpCommand) Register(r Registerer) {
 func (cmd *SignUpCommand) Run() error {
 	profileDir, err := cmd.credentialStore.NewProfileDir()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	credentialPath := profileDir.CredentialPath()
 
@@ -66,7 +65,7 @@ func (cmd *SignUpCommand) Run() error {
 	} else {
 		exists, err := cmd.credentialStore.CredentialExists()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		if exists {
 			confirmed, err := ui.AskYesNo(
@@ -77,7 +76,7 @@ func (cmd *SignUpCommand) Run() error {
 			if err == ui.ErrCannotAsk {
 				return ErrLocalAccountFound
 			} else if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			if !confirmed {
@@ -89,7 +88,7 @@ func (cmd *SignUpCommand) Run() error {
 		if cmd.username == "" || cmd.fullName == "" || cmd.email == "" {
 			_, promptOut, err := cmd.io.Prompts()
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			fmt.Fprint(
 				promptOut,
@@ -100,19 +99,19 @@ func (cmd *SignUpCommand) Run() error {
 			if cmd.username == "" {
 				cmd.username, err = ui.AskAndValidate(cmd.io, "The username you'd like to use: ", 2, api.ValidateUsername)
 				if err != nil {
-					return errio.Error(err)
+					return err
 				}
 			}
 			if cmd.fullName == "" {
 				cmd.fullName, err = ui.AskAndValidate(cmd.io, "Your full name: ", 2, api.ValidateFullName)
 				if err != nil {
-					return errio.Error(err)
+					return err
 				}
 			}
 			if cmd.email == "" {
 				cmd.email, err = ui.AskAndValidate(cmd.io, "Your email address: ", 2, api.ValidateEmail)
 				if err != nil {
-					return errio.Error(err)
+					return err
 				}
 			}
 		}
@@ -132,7 +131,7 @@ func (cmd *SignUpCommand) Run() error {
 	if !cmd.credentialStore.IsPassphraseSet() && !cmd.force {
 		passphrase, err := ui.AskPassphrase(cmd.io, "Please enter a passphrase to protect your local credential (leave empty for no passphrase): ", "Enter the same passphrase again: ", 3)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		cmd.credentialStore.SetPassphrase(passphrase)
 	}
@@ -141,14 +140,14 @@ func (cmd *SignUpCommand) Run() error {
 	cmd.progressPrinter.Start()
 	credential, err := secrethub.GenerateCredential()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	cmd.credentialStore.Set(credential)
 	cmd.progressPrinter.Stop()
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprint(cmd.io.Stdout(), "Signing you up...")
@@ -156,11 +155,11 @@ func (cmd *SignUpCommand) Run() error {
 	_, err = client.Users().Create(cmd.username, cmd.email, cmd.fullName)
 	cmd.progressPrinter.Stop()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	err = cmd.credentialStore.Save()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Signup complete! You're now on SecretHub.")

--- a/internals/secrethub/templates.go
+++ b/internals/secrethub/templates.go
@@ -27,10 +27,11 @@ Commands:
 {{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
 {{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
-{{.Help|Wrap 0}}\
+{{.Help}}\
 {{end}}\
 
 {{if .Flags}}
+
 Flags:
 {{.Flags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end}}\

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 // TreeCommand lists the contents of a directory at a given path in a tree-like format.
@@ -30,12 +29,12 @@ func NewTreeCommand(io ui.IO, clientFactory newClientFunc) *TreeCommand {
 func (cmd *TreeCommand) Run() error {
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	t, err := client.Dirs().GetTree(cmd.path.Value(), -1, false)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	printTree(t, cmd.io.Stdout())

--- a/internals/secrethub/write.go
+++ b/internals/secrethub/write.go
@@ -9,7 +9,6 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 var (
@@ -61,7 +60,7 @@ func (cmd *WriteCommand) Run() error {
 	if cmd.useClipboard {
 		data, err = cmd.clipper.ReadAll()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	} else if cmd.io.Stdin().IsPiped() {
 		data, err = ioutil.ReadAll(cmd.io.Stdin())
@@ -71,7 +70,7 @@ func (cmd *WriteCommand) Run() error {
 	} else {
 		str, err := ui.AskSecret(cmd.io, "Please type in the value of the secret, followed by an [ENTER]:")
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 		data = []byte(str)
 	}
@@ -87,22 +86,22 @@ func (cmd *WriteCommand) Run() error {
 
 	_, err = fmt.Fprint(cmd.io.Stdout(), "Writing secret value...\n")
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	client, err := cmd.newClient()
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	version, err := client.Secrets().Write(cmd.path.Value(), data)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	_, err = fmt.Fprintf(cmd.io.Stdout(), "Write complete! The given value has been written to %s:%d\n", cmd.path, version.Version)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return nil

--- a/internals/secretspec/consumable.go
+++ b/internals/secretspec/consumable.go
@@ -113,12 +113,12 @@ func (p *Presenter) Parse(data []byte) error {
 
 		consumable, err := p.parse(entry)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 
 		for _, c := range p.consumables {
 			if c.Equals(consumable) {
-				return errio.Error(ErrDuplicateSpecEntry(c))
+				return ErrDuplicateSpecEntry(c)
 			}
 		}
 
@@ -133,7 +133,7 @@ func (p *Presenter) Clear() error {
 	for _, consumable := range p.consumables {
 		err := consumable.Clear()
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 	return nil
@@ -148,7 +148,7 @@ func (p *Presenter) parse(config Spec) (Consumable, error) {
 		if ok {
 			consumable, err := parser.Parse(p.rootPath, p.allowMountAnywhere, spec)
 			if err != nil {
-				return nil, errio.Error(err)
+				return nil, err
 			}
 
 			return consumable, nil
@@ -163,7 +163,7 @@ func (p *Presenter) Set(secrets map[string]api.SecretVersion) error {
 	for _, consumable := range p.consumables {
 		err := consumable.Set(secrets)
 		if err != nil {
-			return errio.Error(err)
+			return err
 		}
 	}
 
@@ -232,7 +232,7 @@ func parseTargetOnRootPath(rootPath, target string, allowMountAnywhere bool) (st
 func createTarget(rootPath, target string, allowMountAnywhere bool) (string, error) {
 	target, err := parseTargetOnRootPath(rootPath, target, allowMountAnywhere)
 	if err != nil {
-		return "", errio.Error(err)
+		return "", err
 	}
 
 	err = os.MkdirAll(filepath.Dir(target), 0771)

--- a/internals/secretspec/env.go
+++ b/internals/secretspec/env.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/validation"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 const (
@@ -68,7 +67,7 @@ func (p EnvParser) Parse(rootPath string, allowMountAnywhere bool, config map[st
 
 		v, err := newEnvar(source, target)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 		envars[i] = v
 		i++
@@ -94,7 +93,7 @@ func newEnvar(source string, target string) (*envar, error) {
 	target = strings.TrimSpace(target)
 	err = validation.ValidateEnvarName(target)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	return &envar{

--- a/internals/secretspec/file.go
+++ b/internals/secretspec/file.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/secrethub/secrethub-cli/internals/cli/posix"
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 const (
@@ -50,18 +49,18 @@ func (p FileParser) Parse(rootPath string, allowMountAnywhere bool, config map[s
 	if ok && mode != "" {
 		filemode, err = strToFileMode(mode)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 	}
 
 	file, err := newFile(source, target, filemode)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	err = file.createTarget(rootPath, allowMountAnywhere)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	return file, nil
@@ -102,7 +101,7 @@ func newFile(source string, target string, filemode os.FileMode) (*file, error) 
 func (f *file) createTarget(rootPath string, allowMountAnywhere bool) error {
 	target, err := createTarget(rootPath, f.target, allowMountAnywhere)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 	f.target = target
 	return nil

--- a/internals/secretspec/inject.go
+++ b/internals/secretspec/inject.go
@@ -1,17 +1,15 @@
 package secretspec
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/secrethub/secrethub-cli/internals/tpl"
 
-	"fmt"
-
-	"io/ioutil"
-
 	"github.com/secrethub/secrethub-go/internals/api"
-	"github.com/secrethub/secrethub-go/internals/errio"
+
 	"golang.org/x/text/encoding"
 )
 
@@ -55,7 +53,7 @@ func (p InjectParser) Parse(rootPath string, allowMountAnywhere bool, config map
 
 	target, err := createTarget(rootPath, targetName, allowMountAnywhere)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	filemode := DefaultFileMode
@@ -83,7 +81,7 @@ func (p InjectParser) Parse(rootPath string, allowMountAnywhere bool, config map
 	if ok {
 		inj.encoding, err = EncodingFromString(encodingString)
 		if err != nil {
-			return nil, errio.Error(err)
+			return nil, err
 		}
 	} else {
 		inj.encoding = DetectEncoding(bytes)
@@ -97,12 +95,12 @@ func (p InjectParser) Parse(rootPath string, allowMountAnywhere bool, config map
 
 	decodedBytes, err := inj.encoding.NewDecoder().Bytes(bytes)
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	inj.template, err = tpl.NewParser("${", "}").Parse(string(decodedBytes))
 	if err != nil {
-		return nil, errio.Error(err)
+		return nil, err
 	}
 
 	return &inj, nil
@@ -131,14 +129,14 @@ func (inj *Inject) Set(secrets map[string]api.SecretVersion) error {
 
 	output, err := inj.template.Inject(input)
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	log.Debugf("writing injected file to %s", inj.target)
 
 	encodedBytes, err := inj.encoding.NewEncoder().Bytes([]byte(output))
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	return overwriteFile(inj.target, encodedBytes, inj.filemode)

--- a/internals/winrm/client.go
+++ b/internals/winrm/client.go
@@ -96,7 +96,7 @@ func NewBasicClient(config *Config, username, password string) (*Client, error) 
 		Client: client,
 		auth:   authMethod,
 		config: config,
-	}, errio.Error(err)
+	}, err
 
 }
 
@@ -139,7 +139,7 @@ func NewCertClient(config *Config, clientCert, clientKey []byte) (*Client, error
 		Client: client,
 		auth:   authMethode,
 		config: config,
-	}, errio.Error(err)
+	}, err
 
 }
 
@@ -149,7 +149,7 @@ func newWinRMClient(config *Config, auth authMethod) (*winrm.Client, error) {
 	username, password := auth.getBasic()
 	endpoint := winrm.NewEndpoint(config.Host, config.Port, config.HTTPS, config.SkipVerifyCert, config.CaCert, clientKey, clientCert, 0)
 	client, err := winrm.NewClient(endpoint, username, password)
-	return client, errio.Error(err)
+	return client, err
 }
 
 // Client contains all necessary data for a Client connection.
@@ -194,7 +194,7 @@ func (c *Client) GetServerCert(io ui.IO) error {
 			h := sha1.New()
 			_, err := h.Write(cert.Raw)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			fingerprint := formatHex(h.Sum(nil))
 
@@ -202,7 +202,7 @@ func (c *Client) GetServerCert(io ui.IO) error {
 
 			answer, err := ui.AskYesNo(io, question, ui.DefaultNo)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 
 			if !answer {
@@ -213,11 +213,11 @@ func (c *Client) GetServerCert(io ui.IO) error {
 			// Reinitialise the client with the CaCert.
 			c.Client, err = newWinRMClient(c.config, c.auth)
 			if err != nil {
-				return errio.Error(err)
+				return err
 			}
 			return nil
 		}
-		return errio.Error(err)
+		return err
 	}
 	return nil
 }

--- a/internals/winrm/copy.go
+++ b/internals/winrm/copy.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/masterzen/winrm"
 	"github.com/secrethub/secrethub-go/internals/api/uuid"
-	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 var (
@@ -201,7 +200,7 @@ func restoreContent(client *winrm.Client, fromPath, toPath string) (err error) {
 	go copyFunc(&stdErr, cmd.Stderr, errChannel)
 	err = <-errChannel
 	if err != nil {
-		return errio.Error(err)
+		return err
 	}
 
 	cmd.Wait()


### PR DESCRIPTION
We don't use errio to distinguish between expected and unexpected
errors. This should instead be determined by the caller of the
function that returns the error.

This fixes that some expected errors are indicated as unexpected
errors.