### PR TITLE
Lazily lookup credential in secrethub run

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -173,12 +173,11 @@ func (cmd *RunCommand) Run() error {
 		}
 	}
 
-	client, err := cmd.newClient()
-	if err != nil {
-		return err
-	}
-
 	for path := range secrets {
+		client, err := cmd.newClient()
+		if err != nil {
+			return err
+		}
 		secret, err := client.Secrets().Versions().GetWithData(path)
 		if err != nil {
 			return err

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -451,6 +451,11 @@ func TestRunCommand_Run(t *testing.T) {
 		command RunCommand
 		err     error
 	}{
+		"success, no secrets": {
+			command: RunCommand{
+				command: []string{"echo", "test"},
+			},
+		},
 		"invalid template var: start with a number": {
 			command: RunCommand{
 				templateVars: map[string]string{


### PR DESCRIPTION
Don't create a client in the run command when no secrets are used. Creating a client might prompt the user for their passphrase. We don't want to do that when it's not necessary.

Resolves #121 