### PR TITLE
Increase sleep time in masked writer test

### DIFF
--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -200,7 +200,7 @@ func TestNewMaskedWriter(t *testing.T) {
 			inputFunc: func(w io.Writer) {
 				_, err := w.Write([]byte("fo"))
 				assert.OK(t, err)
-				time.Sleep(time.Millisecond * 2)
+				time.Sleep(time.Millisecond * 5)
 				_, err = w.Write([]byte("o bar test"))
 				assert.OK(t, err)
 			},


### PR DESCRIPTION
The current difference of 1ms between the sleep and the timeout
is sometimes not enough to process the write.
The processing of this write takes place in other goroutines and
is not finished when the sleep starts. When processing takes longer
than 1ms, the timeout does not kick in (as expected), because the
timeout is measured after processing of a write.

This should fix undeterministic failure of the test.