### PR TITLE
Add flag to the run command to suppress errors of non-existing secrets

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -228,7 +228,7 @@ func (cmd *RunCommand) Run() error {
 		cmd.command = strings.Split(cmd.command[0], " ")
 	}
 
-	secretsRead := secretReader.SecretsRead()
+	secretsRead := secretReader.Values()
 
 	maskStrings := make([][]byte, 0, len(secretsRead))
 	i := 0

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -228,15 +228,19 @@ func (cmd *RunCommand) Run() error {
 
 	secretsRead := secretReader.SecretsRead()
 
-	maskStrings := make([][]byte, len(secrets)+len(secretsRead))
+	maskStrings := make([][]byte, 0, len(secrets)+len(secretsRead))
 	i := 0
 	for _, val := range secrets {
-		maskStrings[i] = []byte(val)
-		i++
+		if val != "" {
+			maskStrings[i] = []byte(val)
+			i++
+		}
 	}
 	for _, val := range secretsRead {
-		maskStrings[i] = []byte(val)
-		i++
+		if val != "" {
+			maskStrings[i] = []byte(val)
+			i++
+		}
 	}
 
 	maskedStdout := masker.NewMaskedWriter(os.Stdout, maskStrings, maskString, cmd.maskingTimeout)

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -93,7 +93,7 @@ func (cmd *RunCommand) Register(r Registerer) {
 	clause.Flag("no-masking", "Disable masking of secrets on stdout and stderr").BoolVar(&cmd.noMasking)
 	clause.Flag("masking-timeout", "The maximum time output is buffered. Warning: lowering this value increases the chance of secrets not being masked.").Default("1s").DurationVar(&cmd.maskingTimeout)
 	clause.Flag("template-version", "The template syntax version to be used. The options are v1, v2, latest or auto to automatically detect the version.").Default("auto").StringVar(&cmd.templateVersion)
-	clause.Flag("ignore-missing-secrets", "Do not return an error when a secret does not exist. An empty value is used instead.")
+	clause.Flag("ignore-missing-secrets", "Do not return an error when a secret does not exist and use an empty value instead.")
 
 	BindAction(clause, cmd.Run)
 }

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -228,19 +228,19 @@ func (cmd *RunCommand) Run() error {
 		cmd.command = strings.Split(cmd.command[0], " ")
 	}
 
-	secretsRead := secretReader.Values()
+	values := secretReader.Values()
 
-	maskStrings := make([][]byte, 0, len(secretsRead))
+	valuesToMask := make([][]byte, 0, len(values))
 	i := 0
-	for _, val := range secretsRead {
+	for _, val := range values {
 		if val != "" {
-			maskStrings[i] = []byte(val)
+			valuesToMask[i] = []byte(val)
 			i++
 		}
 	}
 
-	maskedStdout := masker.NewMaskedWriter(os.Stdout, maskStrings, maskString, cmd.maskingTimeout)
-	maskedStderr := masker.NewMaskedWriter(os.Stderr, maskStrings, maskString, cmd.maskingTimeout)
+	maskedStdout := masker.NewMaskedWriter(os.Stdout, valuesToMask, maskString, cmd.maskingTimeout)
+	maskedStderr := masker.NewMaskedWriter(os.Stderr, valuesToMask, maskString, cmd.maskingTimeout)
 
 	command := exec.Command(cmd.command[0], cmd.command[1:]...)
 	command.Env = mapToKeyValueStrings(environment)

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -93,7 +93,7 @@ func (cmd *RunCommand) Register(r Registerer) {
 	clause.Flag("no-masking", "Disable masking of secrets on stdout and stderr").BoolVar(&cmd.noMasking)
 	clause.Flag("masking-timeout", "The maximum time output is buffered. Warning: lowering this value increases the chance of secrets not being masked.").Default("1s").DurationVar(&cmd.maskingTimeout)
 	clause.Flag("template-version", "The template syntax version to be used. The options are v1, v2, latest or auto to automatically detect the version.").Default("auto").StringVar(&cmd.templateVersion)
-	clause.Flag("ignore-missing-secrets", "Do not return an error when a secret does not exist and use an empty value instead.")
+	clause.Flag("ignore-missing-secrets", "Do not return an error when a secret does not exist and use an empty value instead.").BoolVar(&cmd.ignoreMissingSecrets)
 
 	BindAction(clause, cmd.Run)
 }

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -499,6 +499,27 @@ func TestRunCommand_Run(t *testing.T) {
 			},
 			err: nil,
 		},
+		"repo does not exist ignored": {
+			command: RunCommand{
+				command: []string{"echo", "test"},
+				envar: map[string]string{
+					"missing": "unexisting/repo/secret",
+				},
+				newClient: func() (secrethub.Client, error) {
+					return fakeclient.Client{
+						SecretService: &fakeclient.SecretService{
+							VersionService: &fakeclient.SecretVersionService{
+								WithDataGetter: fakeclient.WithDataGetter{
+									Err: api.ErrRepoNotFound,
+								},
+							},
+						},
+					}, nil
+				},
+				ignoreMissingSecrets: true,
+			},
+			err: nil,
+		},
 		"invalid template var: start with a number": {
 			command: RunCommand{
 				templateVars: map[string]string{

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl/fakes"
 	generictpl "github.com/secrethub/secrethub-cli/internals/tpl"
 
+	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
 )
 
 func elemEqual(t *testing.T, actual []envvar, expected []envvar) {
@@ -453,6 +456,48 @@ func TestRunCommand_Run(t *testing.T) {
 			command: RunCommand{
 				command: []string{"echo", "test"},
 			},
+		},
+		"missing secret": {
+			command: RunCommand{
+				command: []string{"echo", "test"},
+				envar: map[string]string{
+					"missing": "path/to/unexisting/secret",
+				},
+				newClient: func() (secrethub.Client, error) {
+					return fakeclient.Client{
+						SecretService: &fakeclient.SecretService{
+							VersionService: &fakeclient.SecretVersionService{
+								WithDataGetter: fakeclient.WithDataGetter{
+									Err: api.ErrSecretNotFound,
+								},
+							},
+						},
+					}, nil
+				},
+				ignoreMissingSecrets: false,
+			},
+			err: api.ErrSecretNotFound,
+		},
+		"missing secret ignored": {
+			command: RunCommand{
+				command: []string{"echo", "test"},
+				envar: map[string]string{
+					"missing": "path/to/unexisting/secret",
+				},
+				newClient: func() (secrethub.Client, error) {
+					return fakeclient.Client{
+						SecretService: &fakeclient.SecretService{
+							VersionService: &fakeclient.SecretVersionService{
+								WithDataGetter: fakeclient.WithDataGetter{
+									Err: api.ErrSecretNotFound,
+								},
+							},
+						},
+					}, nil
+				},
+				ignoreMissingSecrets: true,
+			},
+			err: nil,
 		},
 		"invalid template var: start with a number": {
 			command: RunCommand{

--- a/internals/secrethub/secret_reader.go
+++ b/internals/secrethub/secret_reader.go
@@ -37,7 +37,7 @@ type bufferedSecretReader struct {
 }
 
 // newBufferedSecretReader wraps a secret reader and stores the retrieved
-// secret values for retrieval with the SecretsRead function.
+// secret values for retrieval with the Values function.
 func newBufferedSecretReader(sr tpl.SecretReader) *bufferedSecretReader {
 	return &bufferedSecretReader{
 		secretReader: sr,
@@ -46,7 +46,7 @@ func newBufferedSecretReader(sr tpl.SecretReader) *bufferedSecretReader {
 }
 
 // ReadSecret uses the underlying secret reader to read the secret
-// and stores the result for retrieval with the SecretsRead function.
+// and stores the result for retrieval with the Values function.
 func (sr *bufferedSecretReader) ReadSecret(path string) (string, error) {
 	secret, err := sr.secretReader.ReadSecret(path)
 
@@ -57,8 +57,8 @@ func (sr *bufferedSecretReader) ReadSecret(path string) (string, error) {
 	return secret, err
 }
 
-// SecretsRead returns a list of values read with this secret reader.
-func (sr bufferedSecretReader) SecretsRead() []string {
+// Values returns a list of values read with this secret reader.
+func (sr bufferedSecretReader) Values() []string {
 	return sr.secretsRead
 }
 

--- a/internals/secrethub/secret_reader.go
+++ b/internals/secrethub/secret_reader.go
@@ -2,7 +2,7 @@ package secrethub
 
 import (
 	"github.com/secrethub/secrethub-cli/internals/secrethub/tpl"
-	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/errio"
 )
 
 type secretReader struct {
@@ -76,8 +76,18 @@ func newIgnoreMissingSecretReader(sr tpl.SecretReader) *ignoreMissingSecretReade
 // errors for non-existing secrets. Instead, it returns the empty string.
 func (sr *ignoreMissingSecretReader) ReadSecret(path string) (string, error) {
 	secret, err := sr.secretReader.ReadSecret(path)
-	if err == api.ErrSecretNotFound {
+	if isErrNotFound(err) {
 		return "", nil
 	}
 	return secret, err
+}
+
+// isErrNotFound returns whether the given error is caused by a un-existing resource.
+// TODO: Replace this function with github.com/secrethub/secrethub-go/blob/develop/internals/api.IsErrNotFound once that is released.
+func isErrNotFound(err error) bool {
+	statusError, ok := err.(errio.PublicStatusError)
+	if !ok {
+		return false
+	}
+	return statusError.StatusCode == 404
 }


### PR DESCRIPTION
Resolves #131

This PR includes a fix for handling empty secret values, as secret masking could not handle those yet.