### PR TITLE
Rename description flags and add aliasses

### DIFF
--- a/internals/secrethub/org_init.go
+++ b/internals/secrethub/org_init.go
@@ -28,7 +28,9 @@ func NewOrgInitCommand(io ui.IO, newClient newClientFunc) *OrgInitCommand {
 func (cmd *OrgInitCommand) Register(r Registerer) {
 	clause := r.Command("init", "Initialize a new organization account.")
 	clause.Flag("name", "The name you would like to use for your organization. If not set, you will be asked for it.").SetValue(&cmd.name)
-	clause.Flag("descr", "A description (max 144 chars) for your organization so users will recognize it. If not set, you will be asked for it.").StringVar(&cmd.description)
+	clause.Flag("description", "A description (max 144 chars) for your organization so users will recognize it. If not set, you will be asked for it.").StringVar(&cmd.description)
+	clause.Flag("descr", "").Hidden().StringVar(&cmd.description)
+	clause.Flag("desc", "").Hidden().StringVar(&cmd.description)
 	registerForceFlag(clause).BoolVar(&cmd.force)
 
 	BindAction(clause, cmd.Run)

--- a/internals/secrethub/org_init.go
+++ b/internals/secrethub/org_init.go
@@ -28,7 +28,7 @@ func NewOrgInitCommand(io ui.IO, newClient newClientFunc) *OrgInitCommand {
 func (cmd *OrgInitCommand) Register(r Registerer) {
 	clause := r.Command("init", "Initialize a new organization account.")
 	clause.Flag("name", "The name you would like to use for your organization. If not set, you will be asked for it.").SetValue(&cmd.name)
-	clause.Flag("description", "A description (max 144 chars) for your organization so users will recognize it. If not set, you will be asked for it.").StringVar(&cmd.description)
+	clause.Flag("description", "A description (max 144 chars) for your organization so others will recognize it. If not set, you will be asked for it.").StringVar(&cmd.description)
 	clause.Flag("descr", "").Hidden().StringVar(&cmd.description)
 	clause.Flag("desc", "").Hidden().StringVar(&cmd.description)
 	registerForceFlag(clause).BoolVar(&cmd.force)

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -117,7 +117,7 @@ func (cmd *ServiceInitCommand) Run() error {
 func (cmd *ServiceInitCommand) Register(r Registerer) {
 	clause := r.Command("init", "Create a new service account attached to a repository.")
 	clause.Arg("path", "The service account is attached to the repository in this path and when used together with --permission, an access rule is created on the directory in this path.").Required().SetValue(&cmd.path)
-	clause.Flag("description", "A description for the service").StringVar(&cmd.description)
+	clause.Flag("description", "A description for the service so others will recognize it.").StringVar(&cmd.description)
 	clause.Flag("descr", "").Hidden().StringVar(&cmd.description)
 	clause.Flag("desc", "").Hidden().StringVar(&cmd.description)
 	clause.Flag("permission", "Automatically create an access rule giving the service account permission on the given path argument. Accepts `read`, `write` or `admin`.").SetValue(&cmd.permission)

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -117,7 +117,9 @@ func (cmd *ServiceInitCommand) Run() error {
 func (cmd *ServiceInitCommand) Register(r Registerer) {
 	clause := r.Command("init", "Create a new service account attached to a repository.")
 	clause.Arg("path", "The service account is attached to the repository in this path and when used together with --permission, an access rule is created on the directory in this path.").Required().SetValue(&cmd.path)
-	clause.Flag("desc", "A description for the service").StringVar(&cmd.description)
+	clause.Flag("description", "A description for the service").StringVar(&cmd.description)
+	clause.Flag("descr", "").Hidden().StringVar(&cmd.description)
+	clause.Flag("desc", "").Hidden().StringVar(&cmd.description)
 	clause.Flag("permission", "Automatically create an access rule giving the service account permission on the given path argument. Accepts `read`, `write` or `admin`.").SetValue(&cmd.permission)
 	// TODO make 45 sec configurable
 	clause.Flag("clip", "Write the service account configuration to the clipboard instead of stdout. The clipboard is automatically cleared after 45 seconds.").Short('c').BoolVar(&cmd.clip)


### PR DESCRIPTION
Use `description` as the flag in the help-text and add aliases `descr` and `desc`.