### PR TITLE
 Add type to service ls command 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af
+	github.com/secrethub/secrethub-go v0.20.1-0.20190821121056-8eaaf9673369
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	github.com/secrethub/secrethub-go v0.0.0-20190801115327-20fc784b35e0
+	github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/secrethub/secrethub-go v0.0.0-20190801115327-20fc784b35e0/go.mod h1:E9MecxicOt8/yFp7WzVO5urgUEhbLrqQcGelgEKu+U4=
+github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af h1:Ai2EmOTb7jnJZvXOLrdkM7RVlzR4fLOd//Uph1984+U=
+github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af/go.mod h1:E9MecxicOt8/yFp7WzVO5urgUEhbLrqQcGelgEKu+U4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/secrethub/secrethub-go v0.0.0-20190801115327-20fc784b35e0/go.mod h1:E9MecxicOt8/yFp7WzVO5urgUEhbLrqQcGelgEKu+U4=
 github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af h1:Ai2EmOTb7jnJZvXOLrdkM7RVlzR4fLOd//Uph1984+U=
 github.com/secrethub/secrethub-go v0.20.1-0.20190821082359-26bfe8af56af/go.mod h1:E9MecxicOt8/yFp7WzVO5urgUEhbLrqQcGelgEKu+U4=
+github.com/secrethub/secrethub-go v0.20.1-0.20190821121056-8eaaf9673369 h1:sRuUIraIkQ/Nmajsf8N12D4oQ0d0DURNLi2jjem/X28=
+github.com/secrethub/secrethub-go v0.20.1-0.20190821121056-8eaaf9673369/go.mod h1:E9MecxicOt8/yFp7WzVO5urgUEhbLrqQcGelgEKu+U4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/internals/secrethub/service_ls.go
+++ b/internals/secrethub/service_ls.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
@@ -13,15 +14,17 @@ type ServiceLsCommand struct {
 	repoPath api.RepoPath
 	quiet    bool
 
-	io        ui.IO
-	newClient newClientFunc
+	io           ui.IO
+	newClient    newClientFunc
+	serviceTable serviceTable
 }
 
 // NewServiceLsCommand creates a new ServiceLsCommand.
 func NewServiceLsCommand(io ui.IO, newClient newClientFunc) *ServiceLsCommand {
 	return &ServiceLsCommand{
-		io:        io,
-		newClient: newClient,
+		io:           io,
+		newClient:    newClient,
+		serviceTable: keyServiceTable{},
 	}
 }
 
@@ -53,10 +56,10 @@ func (cmd *ServiceLsCommand) Run() error {
 	} else {
 		w := tabwriter.NewWriter(cmd.io.Stdout(), 0, 2, 2, ' ', 0)
 
-		fmt.Fprintf(w, "%s\t%s\n", "ID", "DESCRIPTION")
+		fmt.Println(w, strings.Join(cmd.serviceTable.header(), "\t"))
 
 		for _, service := range services {
-			fmt.Fprintf(w, "%s\t%s\n", service.ServiceID, service.Description)
+			fmt.Println(w, strings.Join(cmd.serviceTable.row(service), "\t"))
 		}
 
 		err = w.Flush()
@@ -66,4 +69,31 @@ func (cmd *ServiceLsCommand) Run() error {
 	}
 
 	return nil
+}
+
+type serviceTable interface {
+	header() []string
+	row(service *api.Service) []string
+}
+
+type baseServiceTable struct{}
+
+func (sw baseServiceTable) header() []string {
+	return []string{"ID", "DESCRIPTION"}
+}
+
+func (sw baseServiceTable) row(service *api.Service) []string {
+	return []string{service.ServiceID, service.Description}
+}
+
+type keyServiceTable struct {
+	baseServiceTable
+}
+
+func (sw keyServiceTable) header() []string {
+	return append(sw.baseServiceTable.header(), "TYPE")
+}
+
+func (sw keyServiceTable) row(service *api.Service) []string {
+	return append(sw.baseServiceTable.row(service), string(service.Credential.Type))
 }

--- a/internals/secrethub/service_ls.go
+++ b/internals/secrethub/service_ls.go
@@ -56,10 +56,10 @@ func (cmd *ServiceLsCommand) Run() error {
 	} else {
 		w := tabwriter.NewWriter(cmd.io.Stdout(), 0, 2, 2, ' ', 0)
 
-		fmt.Println(w, strings.Join(cmd.serviceTable.header(), "\t"))
+		fmt.Fprintln(w, strings.Join(cmd.serviceTable.header(), "\t"))
 
 		for _, service := range services {
-			fmt.Println(w, strings.Join(cmd.serviceTable.row(service), "\t"))
+			fmt.Fprintln(w, strings.Join(cmd.serviceTable.row(service), "\t"))
 		}
 
 		err = w.Flush()

--- a/internals/secrethub/service_ls_test.go
+++ b/internals/secrethub/service_ls_test.go
@@ -44,7 +44,7 @@ func TestServiceLsCommand_Run(t *testing.T) {
 					},
 				},
 			},
-			out: "ID      DESCRIPTION  TYPE\ntest    foobar     key\nsecond  foobarbaz  key\n",
+			out: "ID      DESCRIPTION  TYPE\ntest    foobar       key\nsecond  foobarbaz    key\n",
 		},
 		"success quiet": {
 			cmd: ServiceLsCommand{

--- a/internals/secrethub/service_ls_test.go
+++ b/internals/secrethub/service_ls_test.go
@@ -21,21 +21,30 @@ func TestServiceLsCommand_Run(t *testing.T) {
 		err            error
 	}{
 		"success": {
+			cmd: ServiceLsCommand{
+				serviceTable: keyServiceTable{},
+			},
 			serviceService: fakeclient.ServiceService{
 				Lister: fakeclient.RepoServiceLister{
 					ReturnsServices: []*api.Service{
 						{
 							ServiceID:   "test",
 							Description: "foobar",
+							Credential: &api.Credential{
+								Type: api.CredentialType("key"),
+							},
 						},
 						{
 							ServiceID:   "second",
 							Description: "foobarbaz",
+							Credential: &api.Credential{
+								Type: api.CredentialType("key"),
+							},
 						},
 					},
 				},
 			},
-			out: "ID      DESCRIPTION\ntest    foobar\nsecond  foobarbaz\n",
+			out: "ID      DESCRIPTION  TYPE\ntest    foobar     key\nsecond  foobarbaz  key\n",
 		},
 		"success quiet": {
 			cmd: ServiceLsCommand{


### PR DESCRIPTION
The translation to columns is injected into the command, so that
we can use different columns in the service aws ls command, which
will be added later.