### PR TITLE
Don't fetch the user in repo invite when not using it

### DIFF
--- a/internals/secrethub/repo_invite.go
+++ b/internals/secrethub/repo_invite.go
@@ -41,12 +41,12 @@ func (cmd *RepoInviteCommand) Run() error {
 		return err
 	}
 
-	user, err := client.Users().Get(cmd.username)
-	if err != nil {
-		return err
-	}
-
 	if !cmd.force {
+		user, err := client.Users().Get(cmd.username)
+		if err != nil {
+			return err
+		}
+
 		msg := fmt.Sprintf("Are you sure you want to add %s to the %s repository?",
 			user.PrettyName(),
 			cmd.path)
@@ -68,7 +68,7 @@ func (cmd *RepoInviteCommand) Run() error {
 		return err
 	}
 
-	fmt.Fprintf(cmd.io.Stdout(), "Invite complete! The user %s is now a member of the %s repository.\n", user.Username, cmd.path)
+	fmt.Fprintf(cmd.io.Stdout(), "Invite complete! The user %s is now a member of the %s repository.\n", cmd.username, cmd.path)
 
 	return nil
 }

--- a/internals/secrethub/repo_invite_test.go
+++ b/internals/secrethub/repo_invite_test.go
@@ -44,19 +44,11 @@ func TestRepoInviteCommand_Run(t *testing.T) {
 				username: "dev1",
 				force:    true,
 			},
-			userService: fakeclient.UserService{
-				Getter: fakeclient.UserGetter{
-					ReturnsUser: &api.User{
-						Username: "dev1",
-					},
-				},
-			},
 			repoUserService: fakeclient.RepoUserService{
 				RepoInviter: fakeclient.RepoInviter{
 					ReturnsRepoMember: &api.RepoMember{},
 				},
 			},
-			getArgUsername:    "dev1",
 			inviteArgUsername: "dev1",
 			inviteArgPath:     "dev2/repo",
 			out:               "Inviting user...\nInvite complete! The user dev1 is now a member of the dev2/repo repository.\n",
@@ -67,19 +59,11 @@ func TestRepoInviteCommand_Run(t *testing.T) {
 				username: "dev1",
 				force:    true,
 			},
-			userService: fakeclient.UserService{
-				Getter: fakeclient.UserGetter{
-					ReturnsUser: &api.User{
-						Username: "dev1",
-					},
-				},
-			},
 			repoUserService: fakeclient.RepoUserService{
 				RepoInviter: fakeclient.RepoInviter{
 					Err: testErr,
 				},
 			},
-			getArgUsername:    "dev1",
 			inviteArgUsername: "dev1",
 			inviteArgPath:     "dev2/repo",
 			out:               "Inviting user...\n",


### PR DESCRIPTION
Only when prompting for confirmation we need extra information to
display. In other cases, we don't need to fetch the extra user
details.