### PR TITLE
Fix masking problem

### DIFF
--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -118,7 +118,9 @@ func NewMaskedWriter(w io.Writer, masks [][]byte, maskString string, timeout tim
 // This function never returns an error. These can instead be caught with Flush().
 func (mw *MaskedWriter) Write(p []byte) (n int, err error) {
 	mw.wg.Add(len(p))
-	mw.incomingBytesCh <- p
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	mw.incomingBytesCh <- tmp
 	return len(p), nil
 }
 

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -121,7 +121,7 @@ func TestMatcher(t *testing.T) {
 func TestNewMaskedWriter(t *testing.T) {
 	maskString := "<redacted by SecretHub>"
 
-	timeout20ms := time.Millisecond * 20
+	timeout10s := time.Second * 10
 	timeout1ms := time.Millisecond * 1
 	timeout0 := time.Second * 0
 
@@ -188,11 +188,11 @@ func TestNewMaskedWriter(t *testing.T) {
 			inputFunc: func(w io.Writer) {
 				_, err := w.Write([]byte("fo"))
 				assert.OK(t, err)
-				time.Sleep(time.Millisecond * 2)
+				time.Sleep(time.Nanosecond * 1)
 				_, err = w.Write([]byte("o test"))
 				assert.OK(t, err)
 			},
-			timeout:  &timeout20ms,
+			timeout:  &timeout10s,
 			expected: maskString + " test",
 		},
 		"outside timeout": {

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -223,8 +223,6 @@ func TestNewMaskedWriter(t *testing.T) {
 		"long input": {
 			maskStrings: []string{},
 			inputFunc: func(w io.Writer) {
-
-				assert.OK(t, err)
 				for _, c := range randomIn {
 					_, err := w.Write([]byte{c})
 					assert.OK(t, err)
@@ -235,8 +233,6 @@ func TestNewMaskedWriter(t *testing.T) {
 		"reuse input buffer": {
 			maskStrings: []string{},
 			inputFunc: func(w io.Writer) {
-
-				assert.OK(t, err)
 				tmp := make([]byte, 1)
 				for _, c := range randomIn {
 					copy(tmp, []byte{c})

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/randchar"
 )
 
 func TestMatcher(t *testing.T) {
@@ -125,6 +126,9 @@ func TestNewMaskedWriter(t *testing.T) {
 	timeout1ms := time.Millisecond * 1
 	timeout0 := time.Second * 0
 
+	randomIn, err := randchar.NewGenerator(true).Generate(10000)
+	assert.OK(t, err)
+
 	tests := map[string]struct {
 		maskStrings []string
 		inputFunc   func(io.Writer)
@@ -215,6 +219,32 @@ func TestNewMaskedWriter(t *testing.T) {
 			},
 			timeout:  &timeout0,
 			expected: "test " + maskString + " test",
+		},
+		"long input": {
+			maskStrings: []string{},
+			inputFunc: func(w io.Writer) {
+
+				assert.OK(t, err)
+				for _, c := range randomIn {
+					_, err := w.Write([]byte{c})
+					assert.OK(t, err)
+				}
+			},
+			expected: string(randomIn),
+		},
+		"reuse input buffer": {
+			maskStrings: []string{},
+			inputFunc: func(w io.Writer) {
+
+				assert.OK(t, err)
+				tmp := make([]byte, 1)
+				for _, c := range randomIn {
+					copy(tmp, []byte{c})
+					_, err := w.Write(tmp)
+					assert.OK(t, err)
+				}
+			},
+			expected: string(randomIn),
 		},
 	}
 


### PR DESCRIPTION
For some inputs, the masking completely garbled the output. For example `secrethub run -- terraform plan` lead to unreadable output.

The cause of this was a wrong implementation of the `io.Writer` interface by `MaskedWriter`. It assumed control of the `[]byte` it takes as input, but it is not allowed to do so. 

The problem is demonstrated in the new `TestNewMaskedWriter/reuse_input_buffer` test.