### PR TITLE
Add nfpms to build .deb and .rpm packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,3 +76,16 @@ scoop:
   description: Command-line interface for SecretHub
 
   license: Apache-2.0
+
+nfpms:
+  -
+    vendor: SecretHub
+    homepage: https://secrethub.io/
+    description: CLI for using the SecretHub Secret Management Service
+    license: Apache 2.0
+    formats:
+      - rpm
+      - deb
+    recommends:
+      - xclip
+    bindir: /usr/local

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,9 @@
 project_name: secrethub
 
 builds:
-  - binary: "secrethub"
+  - &default
+    id: default
+    binary: "bin/secrethub"
     env:
       - CGO_ENABLED=0
     goos:
@@ -33,9 +35,14 @@ builds:
       - -s -w -X "github.com/secrethub/secrethub-cli/internals/secrethub.Commit={{ .ShortCommit }}" -X "github.com/secrethub/secrethub-cli/internals/secrethub.Version={{ .Version }}"
     flags:
       - -tags=production
+  - <<: *default
+    id: "without-bin-dir"
+    binary: "secrethub"
 
 archive:
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  builds:
+    - default
   format_overrides:
     - goos: windows
       format: zip
@@ -47,6 +54,8 @@ checksum:
 
 brew:
   name: secrethub-cli
+  ids:
+    - default
   github:
     owner: secrethub
     name: homebrew-tools
@@ -57,6 +66,8 @@ brew:
 
 snapcraft:
   name: secrethub-cli
+  builds:
+    - default
   publish: true
   summary: Command-line interface for SecretHub
   description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts. It enables you to securely share passwords and other secrets with your team and infrastructure.
@@ -79,11 +90,14 @@ scoop:
 
 nfpms:
   -
+    builds:
+      - without-bin-dir
     vendor: SecretHub
     homepage: https://secrethub.io/
     description: CLI for using the SecretHub Secret Management Service
     maintainer: SecretHub Support <support@secrethub.io>
     license: Apache 2.0
+    bindir: /usr/bin
     formats:
       - rpm
       - deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: secrethub
 
 builds:
-  - binary: "bin/secrethub"
+  - binary: "secrethub"
     env:
       - CGO_ENABLED=0
     goos:
@@ -89,4 +89,3 @@ nfpms:
       - deb
     recommends:
       - xclip
-    bindir: /usr/local

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,3 +89,7 @@ nfpms:
       - deb
     recommends:
       - xclip
+    scripts:
+      postinstall: "scripts/post-install.sh"
+      postremove: "scripts/post-remove.sh"
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,7 @@ nfpms:
     vendor: SecretHub
     homepage: https://secrethub.io/
     description: CLI for using the SecretHub Secret Management Service
+    maintainer: SecretHub Support <support@secrethub.io>
     license: Apache 2.0
     formats:
       - rpm

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -5,13 +5,3 @@ if [ -d ${BASH_COMPLETION_DIR} ]; then
     echo -e "==> Installing completion for Bash"
     /usr/bin/secrethub --completion-script-bash > ${BASH_COMPLETION_DIR}/secrethub
 fi
-
-if command -v zsh > /dev/null 2>&1; then
-    echo -e "==> Installing completion for ZSH"
-    mkdir -p ~/.zsh/completion
-    /usr/local/bin/secrethub --completion-script-zsh > ~/.zsh/completion/secrethub
-
-    if ! grep -q "source ~/.zsh/completion/secrethub" ~/.zshrc; then
-        echo "source ~/.zsh/completion/secrethub" >> ~/.zshrc
-    fi
-fi

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env sh
 
 if [ -d /etc/bash_completion.d/ ]; then
-    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    echo -e "==> Installing completion for Bash"
     /usr/local/bin/secrethub --completion-script-bash > /etc/bash_completion.d/secrethub
 elif [ -d /usr/local/etc/bash_completion.d/ ]; then
-    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    echo -e "==> Installing completion for Bash"
     /usr/local/bin/secrethub --completion-script-bash > /usr/local/etc/bash_completion.d/secrethub
 fi
 
 if command -v zsh > /dev/null 2>&1; then
-    echo -e "${OK_COLOR}==> Installing completion for ZSH${NO_COLOR}"
+    echo -e "==> Installing completion for ZSH"
     mkdir -p ~/.zsh/completion
     /usr/local/bin/secrethub --completion-script-zsh > ~/.zsh/completion/secrethub
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-if [ -d /etc/bash_completion.d/ ]; then
+BASH_COMPLETION_DIR=$(pkg-config --variable=completionsdir bash-completion)
+if [ -d ${BASH_COMPLETION_DIR} ]; then
     echo -e "==> Installing completion for Bash"
-    /usr/local/bin/secrethub --completion-script-bash > /etc/bash_completion.d/secrethub
-elif [ -d /usr/local/etc/bash_completion.d/ ]; then
-    echo -e "==> Installing completion for Bash"
-    /usr/local/bin/secrethub --completion-script-bash > /usr/local/etc/bash_completion.d/secrethub
+    /usr/bin/secrethub --completion-script-bash > ${BASH_COMPLETION_DIR}/secrethub
 fi
 
 if command -v zsh > /dev/null 2>&1; then

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+if [ -d /etc/bash_completion.d/ ]; then
+    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    /usr/local/bin/secrethub --completion-script-bash > /etc/bash_completion.d/secrethub
+elif [ -d /usr/local/etc/bash_completion.d/ ]; then
+    echo -e "${OK_COLOR}==> Installing completion for Bash${NO_COLOR}"
+    /usr/local/bin/secrethub --completion-script-bash > /usr/local/etc/bash_completion.d/secrethub
+fi
+
+if command -v zsh > /dev/null 2>&1; then
+    echo -e "${OK_COLOR}==> Installing completion for ZSH${NO_COLOR}"
+    mkdir -p ~/.zsh/completion
+    /usr/local/bin/secrethub --completion-script-zsh > ~/.zsh/completion/secrethub
+
+    if ! grep -q "source ~/.zsh/completion/secrethub" ~/.zshrc; then
+        echo "source ~/.zsh/completion/secrethub" >> ~/.zshrc
+    fi
+fi

--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+rm -f /etc/bash_completion.d/secrethub
+rm -f /usr/local/etc/bash_completion.d/secrethub
+rm -f ~/.zsh/completion/secrethub
+
+sed -i "/source ~\/.zsh\/completion\/secrethub/d" ~/.zshrc > /dev/null 2>&1
+sed -i "" "/source ~\/.zsh\/completion\/secrethub/d" ~/.zshrc > /dev/null 2>&1

--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env sh
 
-rm -f /etc/bash_completion.d/secrethub
-rm -f /usr/local/etc/bash_completion.d/secrethub
-rm -f ~/.zsh/completion/secrethub
-
-sed -i "/source ~\/.zsh\/completion\/secrethub/d" ~/.zshrc > /dev/null 2>&1
-sed -i "" "/source ~\/.zsh\/completion\/secrethub/d" ~/.zshrc > /dev/null 2>&1
+BASH_COMPLETION_DIR=$(pkg-config --variable=completionsdir bash-completion)
+if [ -d ${BASH_COMPLETION_DIR} ]; then
+    rm -f ${BASH_COMPLETION_DIR}/secrethub
+fi


### PR DESCRIPTION
Especially the `.rpm` is handy for AWS. Allows us to do the following for installing on AWS Linux AMI:

```
yum install -y https://github.com/secrethub/secrethub-cli/releases/latest/download/secrethub-cli-amd64.rpm
```