### PR TITLE
Create a start repository on signup

### DIFF
--- a/internals/secrethub/account_init.go
+++ b/internals/secrethub/account_init.go
@@ -232,6 +232,8 @@ func (cmd *AccountInitCommand) Run() error {
 // createAccountKey polls the server on /me/user until the credential is
 // added to the account. When the credential is added to the account, it
 // creates an account key for the credential.
+// When the account key is created, a start repository is created, so that
+// the user can start by reading their first secret.
 func (cmd *AccountInitCommand) createAccountKey() error {
 	client, err := cmd.newClient()
 	if err != nil {
@@ -297,7 +299,7 @@ func (cmd *AccountInitCommand) createAccountKey() error {
 
 	fmt.Fprintln(cmd.io.Stdout(), " Done")
 
-	return nil
+	return createStartRepo(client, cmd.io.Stdout(), me.Username, me.FullName)
 }
 
 // waitForCredentialToBeAdded returns a channel on which is returned when the credential is added and a channel

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -2,12 +2,14 @@ package secrethub
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/progress"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
 	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
 	"github.com/secrethub/secrethub-go/pkg/secretpath"
 )
@@ -160,22 +162,28 @@ func (cmd *SignUpCommand) Run() error {
 
 	fmt.Fprintln(cmd.io.Stdout(), "Signup complete! You're now on SecretHub.")
 
-	fmt.Fprintln(cmd.io.Stdout(), "Setting up a start workspace...")
+	return createStartRepo(client, cmd.io.Stdout(), cmd.username, cmd.fullName)
+}
 
-	repoPath := secretpath.Join(cmd.username, "start")
-	_, err = client.Repos().Create(secretpath.Join(repoPath))
+// createStartRepo creates a start repository and write a fist secret to it, so that
+// the user can start by reading their first secret. This is intended to smoothen
+// onboarding.
+func createStartRepo(client secrethub.ClientInterface, w io.Writer, workspace string, name string) error {
+	fmt.Fprintln(w, "Setting up a start workspace...")
+	repoPath := secretpath.Join(workspace, "start")
+	_, err := client.Repos().Create(secretpath.Join(repoPath))
 	if err != nil {
 		return err
 	}
 
 	secretPath := secretpath.Join(repoPath, "hello")
-	message := fmt.Sprintf("Welcome %s! This is your first secret. To write a new version of this secret, run:\n\n    secrethub write %s", cmd.fullName, secretPath)
+	message := fmt.Sprintf("Welcome %s! This is your first secret. To write a new version of this secret, run:\n\n    secrethub write %s", name, secretPath)
 
 	_, err = client.Secrets().Write(secretPath, []byte(message))
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cmd.io.Stdout(), "Setup complete. To read your first secret, run:\n\n    secrethub read %s\n\n", secretPath)
+	fmt.Fprintf(w, "Setup complete. To read your first secret, run:\n\n    secrethub read %s\n\n", secretPath)
 	return nil
 }

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
+	"github.com/secrethub/secrethub-go/pkg/secretpath"
 )
 
 // Errors
@@ -158,6 +159,21 @@ func (cmd *SignUpCommand) Run() error {
 	}
 
 	fmt.Fprintln(cmd.io.Stdout(), "Signup complete! You're now on SecretHub.")
-	fmt.Fprintf(cmd.io.Stdout(), "Please verify your email address to continue. We've sent a verification mail to %s\n", cmd.email)
+
+	fmt.Fprintln(cmd.io.Stdout(), "Setting up a start workspace.")
+
+	repoPath := secretpath.Join(cmd.username, "start")
+	_, err = client.Repos().Create(secretpath.Join(repoPath))
+	if err != nil {
+		return err
+	}
+
+	secretPath := secretpath.Join(repoPath, "hello")
+	_, err = client.Secrets().Write(secretPath, []byte("Welcome to SecretHub!"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.io.Stdout(), "Setup complete. You can read your first secret with `secrethub read %s`\n", secretPath)
 	return nil
 }

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -160,7 +160,7 @@ func (cmd *SignUpCommand) Run() error {
 
 	fmt.Fprintln(cmd.io.Stdout(), "Signup complete! You're now on SecretHub.")
 
-	fmt.Fprintln(cmd.io.Stdout(), "Setting up a start workspace.")
+	fmt.Fprintln(cmd.io.Stdout(), "Setting up a start workspace...")
 
 	repoPath := secretpath.Join(cmd.username, "start")
 	_, err = client.Repos().Create(secretpath.Join(repoPath))
@@ -169,11 +169,13 @@ func (cmd *SignUpCommand) Run() error {
 	}
 
 	secretPath := secretpath.Join(repoPath, "hello")
-	_, err = client.Secrets().Write(secretPath, []byte("Welcome to SecretHub!"))
+	message := fmt.Sprintf("Welcome %s! This is your first secret. To write a new version of this secret, run:\n\n    secrethub write %s", cmd.fullName, secretPath)
+
+	_, err = client.Secrets().Write(secretPath, []byte(message))
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cmd.io.Stdout(), "Setup complete. You can read your first secret with `secrethub read %s`\n", secretPath)
+	fmt.Fprintf(cmd.io.Stdout(), "Setup complete. To read your first secret, run:\n\n    secrethub read %s\n\n", secretPath)
 	return nil
 }

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -169,7 +169,7 @@ func (cmd *SignUpCommand) Run() error {
 // the user can start by reading their first secret. This is intended to smoothen
 // onboarding.
 func createStartRepo(client secrethub.ClientInterface, w io.Writer, workspace string, name string) error {
-	fmt.Fprintln(w, "Setting up a start workspace...")
+	fmt.Fprintln(w, "Setting up your workspace...")
 	repoPath := secretpath.Join(workspace, "start")
 	_, err := client.Repos().Create(secretpath.Join(repoPath))
 	if err != nil {


### PR DESCRIPTION
This sets up a repository and writes the first secret on signup,
so that the user can start by reading their first secret. This is
intended to smoothen onboarding of new users.

Also, we no longer print the email address should be validated first,
as we have moved this constraint to the moment when users start
collaborating (org invite).