### PR TITLE
Use full command in flag envvars for subcommands

### DIFF
--- a/internals/cli/env.go
+++ b/internals/cli/env.go
@@ -175,7 +175,8 @@ func (cmd *CommandClause) Hidden() *CommandClause {
 // adding an environment variable default configurable by APP_COMMAND_FLAG_NAME.
 // The help text is suffixed with a description of secrthe environment variable default.
 func (cmd *CommandClause) Flag(name, help string) *Flag {
-	prefix := formatName(cmd.name, cmd.app.name, cmd.app.separator, cmd.app.delimiters...)
+	fullCmd := strings.Replace(cmd.FullCommand(), " ", cmd.app.separator, -1)
+	prefix := formatName(fullCmd, cmd.app.name, cmd.app.separator, cmd.app.delimiters...)
 	envVar := formatName(name, prefix, cmd.app.separator, cmd.app.delimiters...)
 
 	cmd.app.registerEnvVar(envVar)


### PR DESCRIPTION
Use `SECRETHUB_<management command>_<command>_<flag>` as envvar
for subcommands, instead of using `SECRETHUB_<command>_<flag>`.