### PR TITLE
 Rename generate rand to generate and make length a flag 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	golang.org/x/text v0.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+replace github.com/alecthomas/kingpin => github.com/secrethub/kingpin v0.0.0-20190920111600-67b1cb231087

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/secrethub/kingpin v0.0.0-20190920111600-67b1cb231087 h1:n4V94OQPe04crRRmcyAURLk3AImueFd44Ne99sN5TO8=
+github.com/secrethub/kingpin v0.0.0-20190920111600-67b1cb231087/go.mod h1:idxgS9pV6OOpAhZvx+gcoGRMX9/tt0iqkw/pNxI0C14=
 github.com/secrethub/secrethub-go v0.21.0 h1:5xbC+gdku7MXUQmlP5SPhAPLF+/U31soLKbyXwNyM+M=
 github.com/secrethub/secrethub-go v0.21.0/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -2,9 +2,12 @@ package secrethub
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/secrethub/secrethub-go/internals/api"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
-	"github.com/secrethub/secrethub-go/internals/api"
+
 	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/randchar"
 )
@@ -13,16 +16,21 @@ var (
 	errGenerate = errio.Namespace("generate")
 
 	// ErrInvalidRandLength is returned when an invalid length is given.
-	ErrInvalidRandLength = errGenerate.Code("invalid_rand_length").Error("The secret length must be larger than 0")
+	ErrInvalidRandLength         = errGenerate.Code("invalid_rand_length").Error("The secret length must be larger than 0")
+	ErrCannotUseLengthArgAndFlag = errGenerate.Code("length_arg_and_flag").Error("length cannot be provided as an argument and a flag at the same time")
 )
+
+const defaultLength = 22
 
 // GenerateSecretCommand generates a new secret and writes to the output path.
 type GenerateSecretCommand struct {
 	useSymbols bool
 	generator  randchar.Generator
 	io         ui.IO
-	length     int
-	path       api.SecretPath
+	lengthFlag *int
+	firstArg   string
+	secondArg  string
+	lengthArg  *int
 	newClient  newClientFunc
 }
 
@@ -36,12 +44,14 @@ func NewGenerateSecretCommand(io ui.IO, newClient newClientFunc) *GenerateSecret
 
 // Register registers the command, arguments and flags on the provided Registerer.
 func (cmd *GenerateSecretCommand) Register(r Registerer) {
-	generateCommand := r.Command("generate", "").Hidden()
-
-	clause := generateCommand.Command("rand", "Generate a random secret. By default, it uses numbers (0-9), lowercase letters (a-z) and uppercase letters (A-Z) and a length of 22.")
-	clause.Arg("secret-path", "The path to write the generated secret to (<namespace>/<repo>[/<dir>]/<secret>)").Required().SetValue(&cmd.path)
-	clause.Arg("length", "The length of the generated secret. Defaults to 22.").Default("22").IntVar(&cmd.length)
+	clause := r.Command("generate", "Generate a random secret.")
+	clause.HelpLong("By default, it uses numbers (0-9), lowercase letters (a-z) and uppercase letters (A-Z) and a length of 22.")
+	clause.Arg("secret-path", "The path to write the generated secret to (<namespace>/<repo>[/<dir>]/<secret>)").Required().StringVar(&cmd.firstArg)
+	cmd.lengthFlag = clause.Flag("length", "The length of the generated secret. Defaults to "+strconv.Itoa(defaultLength)).PlaceHolder(strconv.Itoa(defaultLength)).Int()
 	clause.Flag("symbols", "Include symbols in secret.").Short('s').BoolVar(&cmd.useSymbols)
+
+	clause.Arg("rand-command", "").Hidden().StringVar(&cmd.secondArg)
+	cmd.lengthArg = clause.Arg("length", "").Hidden().Int()
 
 	// TODO SHDEV-528: implement --clip
 	// clause.Flag("clip", "Copy the secret value to the clipboard. The clipboard is automatically cleared after 45 seconds.").Short('c').BoolVar(cmd.clip)
@@ -62,13 +72,23 @@ func (cmd *GenerateSecretCommand) Run() error {
 
 // run generates a new secret and writes to the output path.
 func (cmd *GenerateSecretCommand) run() error {
-	if cmd.length <= 0 {
+	length, err := cmd.length()
+	if err != nil {
+		return err
+	}
+
+	path, err := cmd.path()
+	if err != nil {
+		return err
+	}
+
+	if length <= 0 {
 		return ErrInvalidRandLength
 	}
 
 	fmt.Fprint(cmd.io.Stdout(), "Generating secret value...\n")
 
-	data, err := cmd.generator.Generate(cmd.length)
+	data, err := cmd.generator.Generate(length)
 	if err != nil {
 		return err
 	}
@@ -80,12 +100,32 @@ func (cmd *GenerateSecretCommand) run() error {
 
 	fmt.Fprint(cmd.io.Stdout(), "Writing secret value...\n")
 
-	version, err := client.Secrets().Write(cmd.path.Value(), data)
+	version, err := client.Secrets().Write(path, data)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cmd.io.Stdout(), "Write complete! A randomly generated secret has been written to %s:%d.\n", cmd.path, version.Version)
+	fmt.Fprintf(cmd.io.Stdout(), "Write complete! A randomly generated secret has been written to %s:%d.\n", path, version.Version)
 
 	return nil
+}
+
+func (cmd *GenerateSecretCommand) length() (int, error) {
+	if cmd.lengthArg != nil && cmd.lengthFlag != nil {
+		return 0, ErrCannotUseLengthArgAndFlag
+	}
+	if cmd.lengthFlag != nil {
+		return *cmd.lengthFlag, nil
+	}
+	if cmd.lengthArg != nil {
+		return *cmd.lengthArg, nil
+	}
+	return defaultLength, nil
+}
+
+func (cmd *GenerateSecretCommand) path() (string, error) {
+	if cmd.firstArg == "rand" {
+		return cmd.secondArg, api.ValidateSecretPath(cmd.secondArg)
+	}
+	return cmd.firstArg, api.ValidateSecretPath(cmd.firstArg)
 }

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/secrethub/secrethub-go/internals/api"
-
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 
+	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/errio"
 	"github.com/secrethub/secrethub-go/pkg/randchar"
 )

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -47,7 +47,7 @@ func (cmd *GenerateSecretCommand) Register(r Registerer) {
 	clause := r.Command("generate", "Generate a random secret.")
 	clause.HelpLong("By default, it uses numbers (0-9), lowercase letters (a-z) and uppercase letters (A-Z) and a length of 22.")
 	clause.Arg("secret-path", "The path to write the generated secret to (<namespace>/<repo>[/<dir>]/<secret>)").Required().StringVar(&cmd.firstArg)
-	clause.Flag("length", "The length of the generated secret. Defaults to "+strconv.Itoa(defaultLength)).PlaceHolder(strconv.Itoa(defaultLength)).SetValue(&cmd.lengthFlag)
+	clause.Flag("length", "The length of the generated secret. Defaults to "+strconv.Itoa(defaultLength)).PlaceHolder(strconv.Itoa(defaultLength)).Short('l').SetValue(&cmd.lengthFlag)
 	clause.Flag("symbols", "Include symbols in secret.").Short('s').BoolVar(&cmd.useSymbols)
 
 	clause.Arg("rand-command", "").Hidden().StringVar(&cmd.secondArg)

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -131,7 +131,7 @@ func (cmd *GenerateSecretCommand) path() (string, error) {
 		return "", fmt.Errorf("unexpected %s", cmd.secondArg)
 	}
 	if cmd.lengthArg.IsSet() {
-		return "", fmt.Errorf("unexpected %d", cmd.lengthArg)
+		return "", fmt.Errorf("unexpected %d", cmd.lengthArg.Get())
 	}
 	return cmd.firstArg, api.ValidateSecretPath(cmd.firstArg)
 }

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -127,6 +127,12 @@ func (cmd *GenerateSecretCommand) path() (string, error) {
 	if cmd.firstArg == "rand" {
 		return cmd.secondArg, api.ValidateSecretPath(cmd.secondArg)
 	}
+	if cmd.secondArg != "" {
+		return "", fmt.Errorf("unexpected %s", cmd.secondArg)
+	}
+	if cmd.lengthArg.IsSet() {
+		return "", fmt.Errorf("unexpected %d", cmd.lengthArg)
+	}
 	return cmd.firstArg, api.ValidateSecretPath(cmd.firstArg)
 }
 

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -136,15 +136,15 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		// The length arg is only for backwards compatibility of the `generate rand` command.
 		"length arg without rand": {
 			cmd: GenerateSecretCommand{
-				firstArg: "namespace/repo/secret",
-				lengthArg:newIntValue(24),
+				firstArg:  "namespace/repo/secret",
+				lengthArg: newIntValue(24),
 			},
 			err: errors.New("unexpected 24"),
 		},
 		// The second arg should only be used to supply the path when the first arg is `rand` (backwards compatibility).
 		"second arg without rand": {
 			cmd: GenerateSecretCommand{
-				firstArg: "namespace/repo/secret",
+				firstArg:  "namespace/repo/secret",
 				secondArg: "namespace/repo/secret2",
 			},
 			err: errors.New("unexpected namespace/repo/secret2"),

--- a/internals/secrethub/templates.go
+++ b/internals/secrethub/templates.go
@@ -22,7 +22,7 @@ Commands:
 
 {{define "FormatAppUsage"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{if .Commands}} <command> [<args> ...]{{end}}
 {{if .Help}}
 {{.Help}}\
@@ -43,7 +43,7 @@ Args:
 
 {{define "FormatCommandUsage"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
-{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
 {{if .Commands}} <command> [<args> ...]{{end}}
 {{ if .Help}}
 {{.Help}}\


### PR DESCRIPTION
New: `generate [--length=<length>] <path>`
Old: `generate rand <path> [<length>]` still works.