### PR TITLE
Update kingpin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	bitbucket.org/zombiezen/cardcpx v0.0.0-20150417151802-902f68ff43ef
-	github.com/alecthomas/kingpin v0.0.0-20190705085659-95eb9edaa399
+	github.com/alecthomas/kingpin v0.0.0-20190930021037-0a108b7f5563
 	github.com/atotto/clipboard v0.1.2
 	github.com/aws/aws-sdk-go v1.19.38
 	github.com/danieljoos/wincred v1.0.2 // indirect
@@ -25,5 +25,3 @@ require (
 	golang.org/x/text v0.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-replace github.com/alecthomas/kingpin => github.com/secrethub/kingpin v0.0.0-20190920111600-67b1cb231087

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNf
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/alecthomas/kingpin v0.0.0-20190705085659-95eb9edaa399 h1:NoJOfPUP5uDdYYuWS/+I6UQDH4+Fo1wDlaw4CUEeHmk=
 github.com/alecthomas/kingpin v0.0.0-20190705085659-95eb9edaa399/go.mod h1:idxgS9pV6OOpAhZvx+gcoGRMX9/tt0iqkw/pNxI0C14=
+github.com/alecthomas/kingpin v0.0.0-20190930021037-0a108b7f5563 h1:YT8l7Flq7VNXnjqwtjCF9bzffTPGgedBC+xyj88lVe4=
+github.com/alecthomas/kingpin v0.0.0-20190930021037-0a108b7f5563/go.mod h1:idxgS9pV6OOpAhZvx+gcoGRMX9/tt0iqkw/pNxI0C14=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=


### PR DESCRIPTION
No longer use the SecretHub fork, as the required change has been
merged to the upstream repository.