### PR TITLE
Fix bug MaskedWriter is not flushed before timeout

### DIFF
--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -145,8 +145,8 @@ func (mw *MaskedWriter) process() {
 				mw.flushBuffer()
 			}
 		case p := <-mw.incomingBytesCh:
-			matchInProgress := false
 			for _, b := range p {
+				matchInProgress := false
 				mw.buf = append(mw.buf, maskByte{byte: b})
 
 				for _, matcher := range mw.matchers {

--- a/internals/cli/masker/writer_test.go
+++ b/internals/cli/masker/writer_test.go
@@ -271,7 +271,7 @@ func TestNewMaskedWriter(t *testing.T) {
 	}
 }
 
-func TestNewMaskedWriter_OnlyFlushingOnTimeoutBug(t *testing.T) {
+func TestNewMaskedWriter_FlushBeforeTimeout(t *testing.T) {
 	// There was a bug in MaskedWriter where it was only flushed on a timeout when a secret was found in the middle
 	// of write. This test assures this bug is not present by writing a secret in the middle of a Write and
 	// checking whether Flush() returns before the timeout of the MaskedWriter.


### PR DESCRIPTION
There was a bug in MaskedWriter where it was only flushed on a timeout when a secret was found in the middle of a write. The reason was that `matchInProgress := false` had to be inside the loop instead of outside. Also added a test to test whether the problem is solved.