### PR TITLE
Explicitly set brew install field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,8 @@ brews:
       owner: secrethub
       name: homebrew-tools
     folder: Formula
-
+    install: |
+      bin.install "bin/secrethub"
     homepage: https://secrethub.io
     description: Command-line interface for SecretHub
 


### PR DESCRIPTION
Because the automatically generated value is no good when using multiple
builds.