### PR TITLE
Add --in-file option to write command

### DIFF
--- a/internals/secrethub/write.go
+++ b/internals/secrethub/write.go
@@ -14,7 +14,7 @@ import (
 var (
 	errCannotWriteToVersion = errMain.Code("cannot_write_version").Error("cannot (over)write a specific secret version, they are append only")
 	errEmptySecret          = errMain.Code("cannot_write_empty_secret").Error("secret is empty or contains only whitespace")
-	errClipAndInFile        = errMain.Code("clip_and_in-file").Error("clip and in-file cannot be used together")
+	errClipAndInFile        = errMain.Code("clip_and_in_file").Error("clip and in-file cannot be used together")
 )
 
 // WriteCommand is a command to write content to a secret.

--- a/internals/secrethub/write_test.go
+++ b/internals/secrethub/write_test.go
@@ -193,7 +193,7 @@ func TestWriteCommand_Run(t *testing.T) {
 		},
 		"clip and in-file": {
 			cmd: WriteCommand{
-				inFile: "file",
+				inFile:       "file",
 				useClipboard: true,
 			},
 			err: errClipAndInFile,

--- a/internals/secrethub/write_test.go
+++ b/internals/secrethub/write_test.go
@@ -191,6 +191,13 @@ func TestWriteCommand_Run(t *testing.T) {
 			},
 			err: clip.ErrCannotRead("read error"),
 		},
+		"clip and in-file": {
+			cmd: WriteCommand{
+				inFile: "file",
+				useClipboard: true,
+			},
+			err: errClipAndInFile,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
Write the contents of a file to a secret with the --in-file flag.

Resolves #35