### PR TITLE
Add --out-file and --file-mode flags to read

### DIFF
--- a/internals/secrethub/read.go
+++ b/internals/secrethub/read.go
@@ -15,11 +15,6 @@ import (
 	units "github.com/docker/go-units"
 )
 
-// Errors
-var (
-	errClipAndOutFile = errMain.Code("clip_and_out-file").Error("clip and out-file cannot be used together")
-)
-
 // ReadCommand is a command to read a secret.
 type ReadCommand struct {
 	io                  ui.IO
@@ -71,10 +66,6 @@ func (cmd *ReadCommand) Run() error {
 		return err
 	}
 
-	if cmd.useClipboard && cmd.outFile != "" {
-		return errClipAndOutFile
-	}
-
 	if cmd.useClipboard {
 		err = WriteClipboardAutoClear(secret.Data, cmd.clearClipboardAfter, cmd.clipper)
 		if err != nil {
@@ -87,12 +78,16 @@ func (cmd *ReadCommand) Run() error {
 			cmd.path,
 			units.HumanDuration(cmd.clearClipboardAfter),
 		)
-	} else if cmd.outFile != "" {
+	}
+
+	if cmd.outFile != "" {
 		err = ioutil.WriteFile(cmd.outFile, posix.AddNewLine(secret.Data), cmd.fileMode.FileMode())
 		if err != nil {
 			return ErrCannotWrite(cmd.outFile, err)
 		}
-	} else {
+	}
+
+	if cmd.outFile == "" && !cmd.useClipboard {
 		fmt.Fprintf(cmd.io.Stdout(), "%s", string(posix.AddNewLine(secret.Data)))
 	}
 


### PR DESCRIPTION
Use --out-file (and --file-mode) to write the contents of a secret directly to a file.