### PR TITLE
Fix run and inject when env contains invalid value

### DIFF
--- a/internals/secrethub/inject.go
+++ b/internals/secrethub/inject.go
@@ -98,10 +98,7 @@ func (cmd *InjectCommand) Run() error {
 
 	templateVars := make(map[string]string)
 
-	osEnv, err := parseKeyValueStringsToMap(os.Environ())
-	if err != nil {
-		return err
-	}
+	osEnv, _ := parseKeyValueStringsToMap(os.Environ())
 
 	for k, v := range osEnv {
 		if strings.HasPrefix(k, templateVarEnvVarPrefix) {

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -121,7 +121,7 @@ func (cmd *RunCommand) Run() error {
 		}
 	}
 
-	osEnv, err := parseKeyValueStringsToMap(os.Environ())
+	osEnv, passthroughEnv := parseKeyValueStringsToMap(os.Environ())
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (cmd *RunCommand) Run() error {
 	maskedStderr := masker.NewMaskedWriter(os.Stderr, valuesToMask, maskString, cmd.maskingTimeout)
 
 	command := exec.Command(cmd.command[0], cmd.command[1:]...)
-	command.Env = mapToKeyValueStrings(environment)
+	command.Env = append(passthroughEnv, mapToKeyValueStrings(environment)...)
 	command.Stdin = os.Stdin
 	if cmd.noMasking {
 		command.Stdout = os.Stdout
@@ -323,8 +323,9 @@ func mapToKeyValueStrings(pairs map[string]string) []string {
 // parseKeyValueStringsToMap converts a slice of "key=value" strings to a
 // map of "key":"value" pairs. When duplicate keys occur, the last value is
 // used.
-func parseKeyValueStringsToMap(values []string) (map[string]string, error) {
-	result := make(map[string]string)
+func parseKeyValueStringsToMap(values []string) (map[string]string, []string) {
+	parsedLines := make(map[string]string)
+	var unparsableLines []string
 	for _, kv := range values {
 		split := strings.SplitN(kv, "=", 2)
 		key := strings.TrimSpace(split[0])
@@ -335,13 +336,13 @@ func parseKeyValueStringsToMap(values []string) (map[string]string, error) {
 
 		err := validation.ValidateEnvarName(key)
 		if err != nil {
-			return nil, err
+			unparsableLines = append(unparsableLines, kv)
+		} else {
+			parsedLines[key] = value
 		}
-
-		result[key] = value
 	}
 
-	return result, nil
+	return parsedLines, unparsableLines
 }
 
 // EnvSource defines a method of reading environment variables from a source.

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -657,3 +657,21 @@ func TestTrimQuotes(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseKeyValueStringsToMap(t *testing.T) {
+	input := []string{
+		"A=B",
+		"B",
+		"=::=::\\",
+	}
+
+	parsableValues, unparsableValues := parseKeyValueStringsToMap(input)
+
+	assert.Equal(t, parsableValues, map[string]string{
+		"A": "B",
+		"B": "",
+	})
+	assert.Equal(t, unparsableValues, []string{
+		"=::=::\\",
+	})
+}


### PR DESCRIPTION
On Windows the environment can contain key-value pair that is not valid
according to the standard. Run and inject used to fail on this because
they try to validate every individual key in the environment. When one
is incorrect, they error. E.g., I encountered the following line in
os.Environ() on Windows: =::=::\

This commits fixes this problem by ignoring any invalid lines in the
environment for injection purposes, but appending them to the
environment of the child process in case of a run.