### PR TITLE
Make downloading deps a separate CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,12 @@ jobs:
       - restore_cache:
           keys:
             - go-modules-{{ checksum "go.mod" }}
-      - run: make test
+      - run: go mod download
       - save_cache:
           key: go-modules-{{ checksum "go.mod" }}
           paths:
             - /go/pkg/mod
+      - run: make test
   verify-goreleaser:
     docker:
       - image: goreleaser/goreleaser:v0.117


### PR DESCRIPTION
This makes the logs of the job easier to read. You can easily see
whether downloading the deps succeeded and can check out the test
logs separately, without having the logs of downloading the deps.