### PR TITLE
Add --multiline flag to write command

### DIFF
--- a/internals/cli/ui/ask.go
+++ b/internals/cli/ui/ask.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -55,6 +56,26 @@ func AskSecret(io IO, question string) (string, error) {
 	fmt.Fprintln(promptOut, "")
 
 	return string(raw), nil
+}
+
+// AskMultiline prints out the question and reads back the input until an EOF is reached.
+// The input is displayed to the user.
+func AskMultiline(io IO, question string) ([]byte, error) {
+	promptIn, promptOut, err := io.Prompts()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = fmt.Fprintf(promptOut, "%s\n", question)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := ioutil.ReadAll(promptIn)
+
+	fmt.Fprintln(promptOut)
+
+	return raw, nil
 }
 
 // AskAndValidate asks the user a question and re-prompts the configured amount of times

--- a/internals/cli/ui/ask.go
+++ b/internals/cli/ui/ask.go
@@ -72,9 +72,10 @@ func AskMultiline(io IO, question string) ([]byte, error) {
 	}
 
 	raw, err := ioutil.ReadAll(promptIn)
-
+	if err != nil {
+		return nil, err
+	}
 	fmt.Fprintln(promptOut)
-
 	return raw, nil
 }
 

--- a/internals/cli/ui/io.go
+++ b/internals/cli/ui/io.go
@@ -115,3 +115,9 @@ func (f file) IsPiped() bool {
 
 	return (stat.Mode() & os.ModeCharDevice) == 0
 }
+
+// EOFKey returns the key that should be pressed to enter an EOF.
+// This can be used to end multiline input.
+func EOFKey() string {
+	return eofKey()
+}

--- a/internals/cli/ui/io_unix.go
+++ b/internals/cli/ui/io_unix.go
@@ -18,3 +18,7 @@ func NewUserIO() UserIO {
 
 	return NewStdUserIO()
 }
+
+func eofKey() string {
+	return "CTRL-D"
+}

--- a/internals/cli/ui/io_windows.go
+++ b/internals/cli/ui/io_windows.go
@@ -30,3 +30,7 @@ func (c colorStdout) IsPiped() bool {
 	return os.Getenv("TERM") == "dumb" ||
 		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
 }
+
+func eofKey() string {
+	return "CTRL-Z + ENTER"
+}

--- a/internals/secrethub/write.go
+++ b/internals/secrethub/write.go
@@ -45,7 +45,7 @@ func (cmd *WriteCommand) Register(r command.Registerer) {
 	clause := r.Command("write", "Write a secret.")
 	clause.Arg("secret-path", "The path to the secret").Required().PlaceHolder(secretPathPlaceHolder).SetValue(&cmd.path)
 	clause.Flag("clip", "Use clipboard content as input.").Short('c').BoolVar(&cmd.useClipboard)
-	clause.Flag("multiline", "Prompt for multiple lines of input, until CTRL+D is pressed or an EOF is reached.").Short('m').BoolVar(&cmd.multiline)
+	clause.Flag("multiline", "Prompt for multiple lines of input, until an EOF is reached. On Linux/Mac, press CTRL-D to end input. On Windows, press CTRL-Z and then ENTER to end input.").Short('m').BoolVar(&cmd.multiline)
 	clause.Flag("no-trim", "Do not trim leading and trailing whitespace in the secret.").BoolVar(&cmd.noTrim)
 	clause.Flag("in-file", "Use the contents of this file as the value of the secret.").Short('i').StringVar(&cmd.inFile)
 
@@ -89,7 +89,7 @@ func (cmd *WriteCommand) Run() error {
 		}
 	} else if cmd.multiline {
 		var err error
-		data, err = ui.AskMultiline(cmd.io, "Please type in the value of the secret, followed by [CTRL+D]:")
+		data, err = ui.AskMultiline(cmd.io, "Please type in the value of the secret, followed by ["+ui.EOFKey()+"]:")
 		if err != nil {
 			return err
 		}

--- a/internals/secrethub/write.go
+++ b/internals/secrethub/write.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	errCannotWriteToVersion = errMain.Code("cannot_write_version").Error("cannot (over)write a specific secret version, they are append only")
-	errEmptySecret          = errMain.Code("cannot_write_empty_secret").Error("secret is empty or contains only whitespace")
-	errClipAndInFile        = errMain.Code("clip_and_in_file").Error("clip and in-file cannot be used together")
+	errCannotWriteToVersion            = errMain.Code("cannot_write_version").Error("cannot (over)write a specific secret version, they are append only")
+	errEmptySecret                     = errMain.Code("cannot_write_empty_secret").Error("secret is empty or contains only whitespace")
+	errClipAndInFile                   = errMain.Code("clip_and_in_file").Error("clip and in-file cannot be used together")
+	errMultilineWithNonInteractiveFlag = errMain.Code("multiline_flag_conflict").Error("multiline cannot be used together with clip or in-file")
 )
 
 // WriteCommand is a command to write content to a secret.
@@ -23,6 +24,7 @@ type WriteCommand struct {
 	io           ui.IO
 	path         api.SecretPath
 	inFile       string
+	multiline    bool
 	useClipboard bool
 	noTrim       bool
 	clipper      clip.Clipper
@@ -43,6 +45,7 @@ func (cmd *WriteCommand) Register(r command.Registerer) {
 	clause := r.Command("write", "Write a secret.")
 	clause.Arg("secret-path", "The path to the secret").Required().PlaceHolder(secretPathPlaceHolder).SetValue(&cmd.path)
 	clause.Flag("clip", "Use clipboard content as input.").Short('c').BoolVar(&cmd.useClipboard)
+	clause.Flag("multiline", "Prompt for multiple lines of input, until CTRL+D is pressed or an EOF is reached.").Short('m').BoolVar(&cmd.multiline)
 	clause.Flag("no-trim", "Do not trim leading and trailing whitespace in the secret.").BoolVar(&cmd.noTrim)
 	clause.Flag("in-file", "Use the contents of this file as the value of the secret.").Short('i').StringVar(&cmd.inFile)
 
@@ -58,6 +61,10 @@ func (cmd *WriteCommand) Run() error {
 	// Without this check here, the user would be prompted for input when io.Stdin is not piped, but the path is incorrect.
 	if cmd.path.HasVersion() {
 		return errCannotWriteToVersion
+	}
+
+	if cmd.multiline && (cmd.useClipboard || cmd.inFile != "") {
+		return errMultilineWithNonInteractiveFlag
 	}
 
 	if cmd.useClipboard && cmd.inFile != "" {
@@ -79,6 +86,12 @@ func (cmd *WriteCommand) Run() error {
 		data, err = ioutil.ReadAll(cmd.io.Stdin())
 		if err != nil {
 			return ui.ErrReadInput(err)
+		}
+	} else if cmd.multiline {
+		var err error
+		data, err = ui.AskMultiline(cmd.io, "Please type in the value of the secret, followed by [CTRL+D]:")
+		if err != nil {
+			return err
 		}
 	} else {
 		str, err := ui.AskSecret(cmd.io, "Please type in the value of the secret, followed by an [ENTER]:")


### PR DESCRIPTION
If `secrethub write --multiline` or `secrethub write -m` is used, the CLI will keep on asking for input until an `EOF` is reached. This can be triggered by the user pressing `CTRL+D` (which is the same). 

```
$ secrethub write --multiline org/repo/secret
Please type in the value of the secret, followed by [CTRL+D]:
user types
a multiline
secret
```

This flag is not allowed together with `--in-file` or `--clip`.