### PR TITLE
Release to develop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,6 +102,8 @@ nfpms:
     formats:
       - rpm
       - deb
+    dependencies:
+      - ca-certificates
     recommends:
       - xclip
     scripts:


### PR DESCRIPTION
This should resolve the problem of the CLI not being able to contact the server when a .deb is installed in the ubuntu Docker image.