### PR TITLE
Suggest credential name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/secrethub/demo-app v0.1.0
-	github.com/secrethub/secrethub-go v0.23.1-0.20191125121802-ef7900d53bf6
+	github.com/secrethub/secrethub-go v0.23.1-0.20191127105721-564fa33f2e5c
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/secrethub/demo-app v0.1.0
-	github.com/secrethub/secrethub-go v0.23.1-0.20191121111129-cfa8e5e98b73
+	github.com/secrethub/secrethub-go v0.23.1-0.20191125121802-ef7900d53bf6
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/secrethub/secrethub-go v0.23.1-0.20191120155249-d1e9b173319d/go.mod h
 github.com/secrethub/secrethub-go v0.23.1-0.20191121111129-cfa8e5e98b73 h1:AZj6jzzDE5CgLauCD5XJ15G8uJlplI1MsI0pn9Tssu0=
 github.com/secrethub/secrethub-go v0.23.1-0.20191121111129-cfa8e5e98b73/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
 github.com/secrethub/secrethub-go v0.23.1-0.20191125121802-ef7900d53bf6/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
+github.com/secrethub/secrethub-go v0.23.1-0.20191127105721-564fa33f2e5c h1:iI+ig3yk0CtWIJf6E/AqHzu+v9AQy85Dj84OYqH1fJc=
+github.com/secrethub/secrethub-go v0.23.1-0.20191127105721-564fa33f2e5c/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/secrethub/secrethub-go v0.23.1-0.20191120155249-d1e9b173319d h1:/fM4B
 github.com/secrethub/secrethub-go v0.23.1-0.20191120155249-d1e9b173319d/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
 github.com/secrethub/secrethub-go v0.23.1-0.20191121111129-cfa8e5e98b73 h1:AZj6jzzDE5CgLauCD5XJ15G8uJlplI1MsI0pn9Tssu0=
 github.com/secrethub/secrethub-go v0.23.1-0.20191121111129-cfa8e5e98b73/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
+github.com/secrethub/secrethub-go v0.23.1-0.20191125121802-ef7900d53bf6/go.mod h1:rc2IfKKBJ4L0wGec0u4XnF5/pe0FFPE4Q1MWfrFso7s=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/internals/cli/ui/ask.go
+++ b/internals/cli/ui/ask.go
@@ -36,6 +36,19 @@ func Ask(io IO, question string) (string, error) {
 	return Readln(r)
 }
 
+// AskWithDefault  prints out the question and reads the first line of input.
+// If no input is given, the default value is returned.
+func AskWithDefault(io IO, question, defaultValue string) (string, error) {
+	res, err := Ask(io, fmt.Sprintf("%s [%s] ", question, defaultValue))
+	if err != nil {
+		return "", err
+	}
+	if res == "" {
+		return defaultValue, nil
+	}
+	return res, nil
+}
+
 // AskSecret prints out the question and reads back the input,
 // without echoing it back. Useful for passwords and other sensitive inputs.
 func AskSecret(io IO, question string) (string, error) {

--- a/internals/cli/ui/ask_test.go
+++ b/internals/cli/ui/ask_test.go
@@ -9,6 +9,45 @@ import (
 	"github.com/secrethub/secrethub-go/internals/assert"
 )
 
+func TestAskWithDefault(t *testing.T) {
+	question := "foo?"
+	defaultValue := "bar"
+	defaultOutput := "foo? [" + defaultValue + "] "
+	cases := map[string]struct {
+		in          []string
+		expected    string
+		expectedOut string
+	}{
+		"value entered": {
+			in:          []string{"foobar\n"},
+			expected:    "foobar",
+			expectedOut: defaultOutput,
+		},
+		"no value entered": {
+			in:          []string{"\n"},
+			expected:    defaultValue,
+			expectedOut: defaultOutput,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Setup
+			io := NewFakeIO()
+			io.PromptIn.Reads = tc.in
+
+			// Run
+			actual, err := AskWithDefault(io, question, defaultValue)
+
+			// Assert
+			assert.OK(t, err)
+			assert.Equal(t, actual, tc.expected)
+
+			assert.Equal(t, io.PromptOut.String(), tc.expectedOut)
+		})
+	}
+}
+
 func TestConfirmCaseInsensitive(t *testing.T) {
 	cases := map[string]struct {
 		expectedConfirmation []string

--- a/internals/secrethub/credential_backup.go
+++ b/internals/secrethub/credential_backup.go
@@ -56,7 +56,7 @@ func (cmd *CredentialBackupCommand) Run() error {
 
 	backupCode := credentials.CreateBackupCode()
 
-	err = client.Credentials().Create(backupCode)
+	err = client.Credentials().Create("", backupCode)
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/credential_backup.go
+++ b/internals/secrethub/credential_backup.go
@@ -56,7 +56,7 @@ func (cmd *CredentialBackupCommand) Run() error {
 
 	backupCode := credentials.CreateBackupCode()
 
-	err = client.Credentials().Create("", backupCode)
+	err = client.Credentials().Create(backupCode, "")
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/init.go
+++ b/internals/secrethub/init.go
@@ -173,7 +173,7 @@ func (cmd *InitCommand) Run() error {
 		}
 
 		key := credentials.CreateKey()
-		err = client.Credentials().Create(deviceName, key)
+		err = client.Credentials().Create(key, deviceName)
 		if err != nil {
 			return err
 		}

--- a/internals/secrethub/init.go
+++ b/internals/secrethub/init.go
@@ -3,6 +3,7 @@ package secrethub
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"time"
 
@@ -156,8 +157,23 @@ func (cmd *InitCommand) Run() error {
 			return nil
 		}
 
+		deviceName := ""
+		question := "What is the name of this device?"
+		hostName, err := os.Hostname()
+		if err == nil {
+			deviceName, err = ui.AskWithDefault(cmd.io, question, hostName)
+			if err != nil {
+				return err
+			}
+		} else {
+			deviceName, err = ui.Ask(cmd.io, question)
+			if err != nil {
+				return err
+			}
+		}
+
 		key := credentials.CreateKey()
-		err = client.Credentials().Create(key)
+		err = client.Credentials().Create(deviceName, key)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds a prompt for the name of the new credential when using `secrethub init` with a backup code:

```
./secrethub init --backup-code 234555352444233cdcd919d0a2a9d82eaa999e7ac800e8fb9bb71fc774a1d8b23
This backup code can be used to recover the account `my-account`
Do you want to continue? [Y/n]: 
What is the name of this device? [coffee-please] 
```

By default, the hostname of the current machine is suggested. For most people, this should suffice.

On signup, this does not add a name to the credential yet because this is a breaking change. Furthermore, it degrades the experience of the signup because we ask another question. We can later add this or implement a feature add a name to a credential that does not have one yet. We should be careful with allowing renames, as this could make forensics more difficult if an account would be compromised.