### PR TITLE
Accept secret paths on acl check

### DIFF
--- a/internals/secrethub/acl_check.go
+++ b/internals/secrethub/acl_check.go
@@ -97,6 +97,8 @@ func (cmd *ACLCheckCommand) listLevels() ([]*api.AccessLevel, error) {
 				return nil, err
 			}
 			return levels, nil
+		} else {
+			return nil, err
 		}
 	} else if err != nil {
 		return nil, err

--- a/internals/secrethub/acl_check.go
+++ b/internals/secrethub/acl_check.go
@@ -85,17 +85,17 @@ func (cmd *ACLCheckCommand) listLevels() ([]*api.AccessLevel, error) {
 
 	path := cmd.path.Value()
 
-	levels, err := client.AccessRules().ListLevels(path)
-	if err == nil {
+	levels, listLevelsErr := client.AccessRules().ListLevels(path)
+	if listLevelsErr == nil {
 		return levels, nil
 	}
-	if !api.IsErrNotFound(err) {
-		return nil, err
+	if !api.IsErrNotFound(listLevelsErr) {
+		return nil, listLevelsErr
 	}
 
 	isSecret, isSecretErr := client.Secrets().Exists(path)
 	if isSecretErr != nil {
-		return nil, err
+		return nil, listLevelsErr
 	}
 	if isSecret {
 		levels, err = client.AccessRules().ListLevels(secretpath.Parent(path))
@@ -104,6 +104,6 @@ func (cmd *ACLCheckCommand) listLevels() ([]*api.AccessLevel, error) {
 		}
 		return levels, nil
 	}
-	return nil, err
+	return nil, listLevelsErr
 
 }

--- a/internals/secrethub/acl_check.go
+++ b/internals/secrethub/acl_check.go
@@ -105,5 +105,4 @@ func (cmd *ACLCheckCommand) listLevels() ([]*api.AccessLevel, error) {
 		return levels, nil
 	}
 	return nil, listLevelsErr
-
 }


### PR DESCRIPTION
When a secret path is supplied on acl check, return the effective permissions of the directory that contains the secret. As permissions reside only on directories, this is also the effective permission of the secret itself.