### PR TITLE
Rephrase template processing error

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -37,7 +37,7 @@ var (
 	ErrReadEnvFile            = errRun.Code("env_file_read_error").ErrorPref("could not read the environment file %s: %s")
 	ErrEnvDirNotFound         = errRun.Code("env_dir_not_found").Error(fmt.Sprintf("could not find specified environment. Make sure you have executed `%s set`.", ApplicationName))
 	ErrTemplate               = errRun.Code("invalid_template").ErrorPref("could not parse template at line %d: %s")
-	ErrParsingTemplate        = errRun.Code("template_parsing_failed").ErrorPref("error while parsing template file '%s': %s")
+	ErrParsingTemplate        = errRun.Code("template_parsing_failed").ErrorPref("error while processing template file '%s': %s")
 	ErrInvalidTemplateVar     = errRun.Code("invalid_template_var").ErrorPref("template variable '%s' is invalid: template variables may only contain uppercase letters, digits, and the '_' (underscore) and are not allowed to start with a number")
 	ErrSecretsNotAllowedInKey = errRun.Code("secret_in_key").Error("secrets are not allowed in run template keys")
 )

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -37,7 +37,7 @@ var (
 	ErrReadEnvFile            = errRun.Code("env_file_read_error").ErrorPref("could not read the environment file %s: %s")
 	ErrEnvDirNotFound         = errRun.Code("env_dir_not_found").Error(fmt.Sprintf("could not find specified environment. Make sure you have executed `%s set`.", ApplicationName))
 	ErrTemplate               = errRun.Code("invalid_template").ErrorPref("could not parse template at line %d: %s")
-	ErrTemplateFile           = errRun.Code("invalid_template_file").ErrorPref("template file '%s' is invalid: %s")
+	ErrParsingTemplate        = errRun.Code("template_parsing_failed").ErrorPref("error while parsing template file '%s': %s")
 	ErrInvalidTemplateVar     = errRun.Code("invalid_template_var").ErrorPref("template variable '%s' is invalid: template variables may only contain uppercase letters, digits, and the '_' (underscore) and are not allowed to start with a number")
 	ErrSecretsNotAllowedInKey = errRun.Code("secret_in_key").Error("secrets are not allowed in run template keys")
 )
@@ -418,7 +418,7 @@ func ReadEnvFile(filepath string, vars map[string]string, parser tpl.Parser) (En
 	}
 	env, err := NewEnv(r, vars, parser)
 	if err != nil {
-		return EnvFile{}, err
+		return EnvFile{}, ErrParsingTemplate(filepath, err)
 	}
 	return EnvFile{
 		path: filepath,
@@ -436,7 +436,7 @@ type EnvFile struct {
 func (e EnvFile) Env(secrets map[string]string, sr tpl.SecretReader) (map[string]string, error) {
 	env, err := e.env.Env(secrets, sr)
 	if err != nil {
-		return nil, ErrTemplateFile(e.path, err)
+		return nil, ErrParsingTemplate(e.path, err)
 	}
 	return env, nil
 }


### PR DESCRIPTION
The CLI will return errors similar to these, when template parsing fails for any reason:

Encountered an error: error while parsing template file 'e1.env': could not parse template at line 1: template is not formatted as key=value pairs (run.invalid_template)  (run.template_file_parsing_failed) 

Encountered an error: error while parsing template file 'e2.env': no value was supplied for template variable 'env' (template.template_var_not_found)  (run.template_file_parsing_failed) 

Encountered an error: error while parsing template file 'e3.env': Secret not found (server.secret_not_found)  (run.template_file_parsing_failed) 

Encountered an error: error while parsing template file 'e4.env': template syntax error at 1:9: expected the closing of a secret tag `}}`, but reached the end of the template. (template.secret_tag_not_closed)  (run.template_file_parsing_failed) 
