### PR TITLE
Use go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - restore_cache:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/secrethub/secrethub-cli
 
-go 1.12
+go 1.13
 
 require (
 	bitbucket.org/zombiezen/cardcpx v0.0.0-20150417151802-902f68ff43ef


### PR DESCRIPTION
This makes it possible to use go 1.13 functionality. That does also mean, that at least go 1.13 is needed to build from source.

This is required for https://github.com/secrethub/secrethub-cli/pull/239