### PR TITLE
Add temporary tests to run command

### DIFF
--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -238,14 +238,14 @@ func (cmd *RunCommand) Run() error {
 		}
 	}
 
-	maskedStdout := masker.NewMaskedWriter(os.Stdout, valuesToMask, maskString, cmd.maskingTimeout)
+	maskedStdout := masker.NewMaskedWriter(cmd.io.Stdout(), valuesToMask, maskString, cmd.maskingTimeout)
 	maskedStderr := masker.NewMaskedWriter(os.Stderr, valuesToMask, maskString, cmd.maskingTimeout)
 
 	command := exec.Command(cmd.command[0], cmd.command[1:]...)
 	command.Env = append(passthroughEnv, mapToKeyValueStrings(environment)...)
-	command.Stdin = os.Stdin
+	command.Stdin = cmd.io.Stdin()
 	if cmd.noMasking {
-		command.Stdout = os.Stdout
+		command.Stdout = cmd.io.Stdout()
 		command.Stderr = os.Stderr
 	} else {
 		command.Stdout = maskedStdout


### PR DESCRIPTION
To increase testability, the `secrethub run` command's code will be refactored.

In order to decrease the risk of introducing new bugs during this procedure, some temporary tests have been added that verify most of the main functionality of the command.

These tests will be rewritten after the refactor, to better follow testing guidelines.