### PR TITLE
Don't release to snapcraft

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,19 +65,6 @@ brews:
     homepage: https://secrethub.io
     description: Command-line interface for SecretHub
 
-snapcrafts:
-  - name: secrethub-cli
-    builds:
-      - default
-    publish: true
-    summary: Command-line interface for SecretHub
-    description: SecretHub is a developer tool to help you keep database passwords, API tokens, and other secrets out of IT automation scripts. It enables you to securely share passwords and other secrets with your team and infrastructure.
-    apps:
-      secrethub:
-        plugs:
-          - home
-          - network
-
 scoop:
   name: secrethub-cli
   bucket:


### PR DESCRIPTION
Due to issues with sandboxed nature of snap and because we now have better deb/apt support, we've chosen to no longer release to snap.