### PR TITLE
Rename deprecated nfpms.name_template field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: make test
   verify-goreleaser:
     docker:
-      - image: goreleaser/goreleaser:v0.117
+      - image: goreleaser/goreleaser:v0.127
     steps:
       - checkout
       - run: goreleaser check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,7 @@ scoop:
   license: Apache-2.0
 
 nfpms:
-  - name_template: "secrethub-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - file_name_template: "secrethub-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     builds:
       - without-bin-dir
     vendor: SecretHub
@@ -96,4 +96,3 @@ nfpms:
     scripts:
       postinstall: "scripts/post-install.sh"
       postremove: "scripts/post-remove.sh"
-


### PR DESCRIPTION
The old name_template is deprecated in favor of new file_name_template
field.

See: https://goreleaser.com/deprecations/#nfpms-name-template