### PR TITLE
Fix mixing stdout and stderr

### DIFF
--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -188,10 +188,10 @@ func (mw *Masker) process() {
 						mw.buf[len(mw.buf)-1-i].byte.masked = true
 					}
 				}
+			}
 
-				if !mw.isMatchInProgress() {
-					mw.flushBuffer()
-				}
+			if !mw.isMatchInProgress() {
+				mw.flushBuffer()
 			}
 		}
 	}

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -180,7 +180,6 @@ func (mw *Masker) process() {
 			}
 		case p := <-mw.incomingBytesCh:
 			for _, b := range p.bytes {
-				matchInProgress := false
 				mw.buf = append(mw.buf, output{byte: maskByte{byte: b}, target: p.target})
 
 				for _, matcher := range mw.matchers[p.target] {
@@ -188,7 +187,13 @@ func (mw *Masker) process() {
 					for i := 0; i < maskLen; i++ {
 						mw.buf[len(mw.buf)-1-i].byte.masked = true
 					}
-					matchInProgress = matchInProgress || matcher.InProgress()
+				}
+
+				matchInProgress := false
+				for _, matchers := range mw.matchers {
+					for _, matcher := range matchers {
+						matchInProgress = matchInProgress || matcher.InProgress()
+					}
 				}
 
 				if !matchInProgress {

--- a/internals/cli/masker/writer.go
+++ b/internals/cli/masker/writer.go
@@ -189,19 +189,23 @@ func (mw *Masker) process() {
 					}
 				}
 
-				matchInProgress := false
-				for _, matchers := range mw.matchers {
-					for _, matcher := range matchers {
-						matchInProgress = matchInProgress || matcher.InProgress()
-					}
-				}
-
-				if !matchInProgress {
+				if !mw.isMatchInProgress() {
 					mw.flushBuffer()
 				}
 			}
 		}
 	}
+}
+
+func (mw *Masker) isMatchInProgress() bool {
+	for _, matchers := range mw.matchers {
+		for _, matcher := range matchers {
+			if matcher.InProgress() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (mw *Masker) flushBuffer() {


### PR DESCRIPTION
Output should be written in the same order it was received, regardless of the target output stream. Before this commit, it was possible that output on stdout and stderr were mixed, because one of them was delayed.