### PR TITLE
Update kingpin to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	bitbucket.org/zombiezen/cardcpx v0.0.0-20150417151802-902f68ff43ef
-	github.com/alecthomas/kingpin v0.0.0-20191009151950-9e366cbf24ad
+	github.com/alecthomas/kingpin v1.3.8-0.20200323085623-b6657d9477a6
 	github.com/atotto/clipboard v0.1.2
 	github.com/aws/aws-sdk-go v1.25.49
 	github.com/docker/go-units v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNf
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/alecthomas/kingpin v0.0.0-20190930021037-0a108b7f5563 h1:YT8l7Flq7VNXnjqwtjCF9bzffTPGgedBC+xyj88lVe4=
 github.com/alecthomas/kingpin v0.0.0-20190930021037-0a108b7f5563/go.mod h1:idxgS9pV6OOpAhZvx+gcoGRMX9/tt0iqkw/pNxI0C14=
-github.com/alecthomas/kingpin v0.0.0-20191009151950-9e366cbf24ad h1:tMnaQBlddYTQC6SHj8IrLTuOf006vB7yUmYn79/QXlM=
-github.com/alecthomas/kingpin v0.0.0-20191009151950-9e366cbf24ad/go.mod h1:idxgS9pV6OOpAhZvx+gcoGRMX9/tt0iqkw/pNxI0C14=
+github.com/alecthomas/kingpin v1.3.8-0.20200323085623-b6657d9477a6 h1:nesv3dEn8GDv0ZMxkoCSvrxOE5KbzXXHtWEqJvYA/gw=
+github.com/alecthomas/kingpin v1.3.8-0.20200323085623-b6657d9477a6/go.mod h1:b6br6/pDFSfMkBgC96TbpOji05q5pa+v5rIlS0Y6XtI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=


### PR DESCRIPTION
This solves two problems with autocompletion:
1. Users no longer get a panic when autocompleting a command after  `secrethub run --`.
2. After `secrethub run --` users no longer get suggestions for secrethub flags when trying to autocomplete a flag.