### PR TITLE
Consistent not found errors

### DIFF
--- a/internals/secrethub/list.go
+++ b/internals/secrethub/list.go
@@ -100,9 +100,7 @@ func (cmd *LsCommand) Run() error {
 	secretPath, err := cmd.path.ToSecretPath()
 	if err == nil {
 		versions, err := client.Secrets().Versions().ListWithoutData(secretPath.Value())
-		if api.IsErrNotFound(err) {
-			return ErrResourceNotFound(cmd.path)
-		} else if err != nil {
+		if err != nil {
 			return err
 		}
 

--- a/internals/secrethub/rm.go
+++ b/internals/secrethub/rm.go
@@ -87,8 +87,8 @@ func (cmd *RmCommand) Run() error {
 
 	// Check if the secret exists first so we can return a generic error here instead of ErrSecretNotFound.
 	_, err = client.Secrets().Get(secretPath.Value())
-	if err != nil {
-		return err
+	if api.IsErrNotFound(err) {
+		return ErrResourceNotFound(cmd.path)
 	}
 
 	return rmSecret(client, secretPath, cmd.force, cmd.io)

--- a/internals/secrethub/rm.go
+++ b/internals/secrethub/rm.go
@@ -87,8 +87,8 @@ func (cmd *RmCommand) Run() error {
 
 	// Check if the secret exists first so we can return a generic error here instead of ErrSecretNotFound.
 	_, err = client.Secrets().Get(secretPath.Value())
-	if api.IsErrNotFound(err) {
-		return ErrResourceNotFound(cmd.path)
+	if err != nil {
+		return err
 	}
 
 	return rmSecret(client, secretPath, cmd.force, cmd.io)


### PR DESCRIPTION
In combination with [this PR](https://github.com/secrethub/secrethub-go/pull/183) on the client, this PR makes the CLI always output a `secret not found` error when a secret is not found, as opposed to returning a `resource not found` error when removing and listing secrets and a `secret not found` error otherwise.