### PR TITLE
Integrated Terraform State Backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,16 +7,19 @@ require (
 	github.com/alecthomas/kingpin v1.3.8-0.20200323085623-b6657d9477a6
 	github.com/atotto/clipboard v0.1.2
 	github.com/aws/aws-sdk-go v1.25.49
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/docker/go-units v0.3.3
 	github.com/fatih/color v1.7.0
 	github.com/masterzen/winrm v0.0.0-20190308153735-1d17eaf15943
 	github.com/mattn/go-colorable v0.1.1
 	github.com/mattn/go-isatty v0.0.7
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/secrethub/demo-app v0.1.0
 	github.com/secrethub/secrethub-go v0.28.0
+	github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go v1.19.38 h1:WKjobgPO4Ua1ww2NJJl2/zQNreUZxvqmEzwMlRjjm9
 github.com/aws/aws-sdk-go v1.19.38/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.49 h1:j5R2Ey+g8qaiy2NJ9iH+KWzDWS4SjXRCjhc22EeQVE4=
 github.com/aws/aws-sdk-go v1.25.49/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -62,6 +64,8 @@ github.com/mattn/go-shellwords v1.0.6 h1:9Jok5pILi5S1MnDirGVTufYGtksUs/V2BWUP3Zk
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
@@ -84,6 +88,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3 h1:UC4iN/yCDCObTBhKzo34/R2U6qptTPmqbzG6UiQVMUQ=
+github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3/go.mod h1:cJTfuBcxkdbj8Mabk4PPdaf0AXv9TYEJmkFxKcWxYY4=
 github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07 h1:U5I57s4ISLpeeLYl8b3MsainSSh9F+mRXauln37b50I=
 github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07/go.mod h1:XlXBIfkGawHNVOHlenOaBW7zlfCh8LovwjOgjamYnkQ=
 golang.org/x/crypto v0.0.0-20190222235706-ffb98f73852f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/internals/integrations/tfstate/backend.go
+++ b/internals/integrations/tfstate/backend.go
@@ -1,0 +1,162 @@
+package tfstate
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/pkg/randchar"
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
+	"github.com/secrethub/secrethub-go/pkg/secretpath"
+)
+
+type backend struct {
+	client secrethub.ClientInterface
+	port   uint16
+	logger io.Writer
+}
+
+func New(client secrethub.ClientInterface, port uint16, logger io.Writer) *backend {
+	return &backend{
+		client: client,
+		port:   port,
+		logger: prefixWriter{
+			Writer: logger,
+			prefix: "[SecretHub]: ",
+		},
+	}
+}
+
+func (b *backend) Serve() error {
+	server := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", b.port),
+		Handler: http.HandlerFunc(b.Handle),
+	}
+	err := server.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	return nil
+}
+
+func (b *backend) Handle(w http.ResponseWriter, r *http.Request) {
+	isChild, err := connectionFromChildProcess(os.Getpid(), r)
+	if err != nil {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	if !isChild {
+		fmt.Println("can only be reached from a process spawned with secrethub run")
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Printf("Errors: %v\n", err)
+		return
+	}
+
+	path, password, ok := r.BasicAuth()
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(b.logger, "set the SecretHub path to the state as the username")
+		return
+	}
+
+	if secretpath.Count(path) < 2 {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(b.logger, "set user to a valid repository or directory. Got: %s\n", path)
+		return
+	}
+
+	statePath := secretpath.Join(path, "state")
+	lockPath := secretpath.Join(path, "lock")
+	passwordPath := secretpath.Join(path, "password")
+
+	secret, err := b.client.Secrets().ReadString(passwordPath)
+	if err != nil && !api.IsErrNotFound(err) {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	} else if err == nil {
+		if password == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "password stored at %s should be set as auth password", passwordPath)
+			return
+		}
+		if password != secret {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, "provided password does not password stored at %s", passwordPath)
+			return
+		}
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		secret, err := b.client.Secrets().Read(statePath)
+		if api.IsErrNotFound(err) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		} else if err != nil {
+			fmt.Fprintf(b.logger, "%v\n", err)
+
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Write(secret.Data)
+	case http.MethodPost:
+		_, err = b.client.Secrets().Write(statePath, body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, err.Error())
+			return
+		}
+	case "LOCK":
+		_, err := b.client.Secrets().Get(lockPath)
+		if !api.IsErrNotFound(err) {
+			w.WriteHeader(http.StatusLocked)
+			return
+		}
+
+		data, err := randchar.Generate(32)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, err.Error())
+			return
+		}
+
+		res, err := b.client.Secrets().Write(lockPath, data)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, err.Error())
+			return
+		}
+		if res.Version != 1 {
+			w.WriteHeader(http.StatusLocked)
+		}
+
+	case "UNLOCK":
+		err := b.client.Secrets().Delete(lockPath)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	default:
+		w.WriteHeader(http.StatusNotImplemented)
+	}
+}
+
+type prefixWriter struct {
+	io.Writer
+	prefix string
+}
+
+func (l prefixWriter) Write(p []byte) (int, error) {
+	_, err := fmt.Fprintf(l.Writer, "%s%s", l.prefix, p)
+	return len(p), err
+}

--- a/internals/integrations/tfstate/pid.go
+++ b/internals/integrations/tfstate/pid.go
@@ -1,0 +1,48 @@
+package tfstate
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/mitchellh/go-ps"
+)
+
+func connectionFromChildProcess(pid int, r *http.Request) (bool, error) {
+	split := strings.Split(r.RemoteAddr, ":")
+	host := net.ParseIP(split[0])
+	port64, err := strconv.ParseUint(split[1], 10, 16)
+	if err != nil {
+		return false, err
+	}
+	port := uint16(port64)
+
+	socks, err := tcpSocks()
+	if err != nil {
+		return false, err
+	}
+	for _, c := range socks {
+		if c.LocalAddress.Equal(host) && c.LocalPort == port {
+			nextProcess := c.Process.PID
+			for {
+				if nextProcess == pid {
+					return true, nil
+				}
+				if nextProcess == 1 {
+					break
+				}
+				parent, err := ps.FindProcess(nextProcess)
+				if err != nil {
+					return false, err
+				}
+				if parent == nil {
+					break
+				}
+
+				nextProcess = parent.PPid()
+			}
+		}
+	}
+	return false, nil
+}

--- a/internals/integrations/tfstate/socks.go
+++ b/internals/integrations/tfstate/socks.go
@@ -1,0 +1,18 @@
+package tfstate
+
+import (
+	"net"
+)
+
+type Connection struct {
+	LocalAddress  net.IP
+	LocalPort     uint16
+	RemoteAddress net.IP
+	RemotePort    uint16
+	Process
+}
+
+type Process struct {
+	PID  int
+	Name string
+}

--- a/internals/integrations/tfstate/socks_darwin.go
+++ b/internals/integrations/tfstate/socks_darwin.go
@@ -1,0 +1,29 @@
+// +build darwin
+
+package tfstate
+
+import (
+	"github.com/weaveworks/procspy"
+)
+
+func tcpSocks() ([]Connection, error) {
+	cs, err := procspy.Connections(true)
+	if err != nil {
+		return nil, err
+	}
+	var res []Connection
+
+	for sock := cs.Next(); sock != nil; sock = cs.Next() {
+		res = append(res, Connection{
+			LocalAddress:  sock.LocalAddress,
+			LocalPort:     sock.LocalPort,
+			RemoteAddress: sock.RemoteAddress,
+			RemotePort:    sock.RemotePort,
+			Process: Process{
+				PID:  int(sock.Proc.PID),
+				Name: sock.Proc.Name,
+			},
+		})
+	}
+	return res
+}

--- a/internals/integrations/tfstate/socks_other.go
+++ b/internals/integrations/tfstate/socks_other.go
@@ -1,0 +1,33 @@
+// +build !darwin
+
+package tfstate
+
+import (
+	"github.com/cakturk/go-netstat/netstat"
+)
+
+func tcpSocks() ([]Connection, error) {
+	socks, err := netstat.TCPSocks(netstat.NoopFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]Connection, len(socks))
+
+	for i, sock := range socks {
+		if sock.Process == nil {
+			continue
+		}
+		res[i] = Connection{
+			LocalAddress:  sock.LocalAddr.IP,
+			LocalPort:     sock.LocalAddr.Port,
+			RemoteAddress: sock.RemoteAddr.IP,
+			RemotePort:    sock.RemoteAddr.Port,
+			Process: Process{
+				PID:  sock.Process.Pid,
+				Name: sock.Process.Name,
+			},
+		}
+	}
+	return res, nil
+}

--- a/internals/integrations/tfstate/state.go
+++ b/internals/integrations/tfstate/state.go
@@ -1,0 +1,96 @@
+package tfstate
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+)
+
+type compressionType string
+
+const (
+	NoCompression   compressionType = "none"
+	GzipCompression                 = "gzip"
+)
+
+var errUnknownCompressionType = errors.New("unknown compression type")
+
+func (t compressionType) Decompress(in []byte) ([]byte, error) {
+	switch t {
+	case NoCompression:
+		return in, nil
+	case GzipCompression:
+		r, err := gzip.NewReader(bytes.NewBuffer(in))
+		if err != nil {
+			return nil, err
+		}
+		return ioutil.ReadAll(r)
+	default:
+		return nil, errUnknownCompressionType
+	}
+}
+
+func (t compressionType) Compress(in []byte) ([]byte, error) {
+	switch t {
+	case NoCompression:
+		return in, nil
+	case GzipCompression:
+		buf := &bytes.Buffer{}
+		w := gzip.NewWriter(buf)
+		_, err := w.Write(in)
+		if err != nil {
+			return nil, err
+		}
+		err = w.Close()
+		return buf.Bytes(), err
+	default:
+		return nil, errUnknownCompressionType
+	}
+}
+
+func UnpackState(in []byte) ([]byte, error) {
+	var compressedState compressedState
+	err := json.Unmarshal(in, &compressedState)
+	if err != nil {
+		return nil, fmt.Errorf("json: %v", err)
+	}
+
+	state, err := compressedState.Decompress()
+	if err != nil {
+		return nil, fmt.Errorf("decompress: %v", err)
+	}
+	return state, nil
+}
+
+func PackState(in []byte) ([]byte, error) {
+	compressedState, err := compressState(in, GzipCompression)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(compressedState, "", "\t")
+}
+
+func compressState(in []byte, compression compressionType) (compressedState, error) {
+	compressed, err := compression.Compress(in)
+	if err != nil {
+		return compressedState{}, fmt.Errorf("compressing state: %v", err)
+	}
+	return compressedState{
+		Compression: compression,
+		Content:     compressed,
+	}, nil
+
+}
+
+type compressedState struct {
+	Compression compressionType `json:"compression"`
+	Content     []byte          `json:"content"`
+}
+
+func (s compressedState) Decompress() ([]byte, error) {
+	return s.Compression.Decompress(s.Content)
+}


### PR DESCRIPTION
This is an MVP of intgerating a tfstate backend into the `secrethub run` command.

It can be used by configuring the following backend in in terraform:
```hcl
terraform {
  backend "http" {
	address="http://localhost:8118"
	unlock_address="http://localhost:8118"
	lock_address="http://localhost:8118"
  	username = "path/to/state/directory"
  }
}
```

The state is served by wrapping Terraform commands in `secrethub run --tfstate`. For example:
```
secrethub run --tfstate -- terraform init -reconfigure
secrethub run --tfstate -- terraform apply
```

This opens up an HTTP-endpoint that Terraform can connect to. This HTTP-endpoint can only be connected to from processes that are a child of `secrethub run`. In other words: it should not be possible for another process than Terraform to connect to this endpoint and read/write the state.

Though not strictly necessary, it is also possible to set a password on the listener. If the secret `path/to/state/directory/password` exists, the value of it must be set in the `password` field of the Terraform backend. If this secret does not exist, the password field can be omitted. 