### PR TITLE
Make proxy for HTTP-client configurable through flag

### DIFF
--- a/internals/secrethub/client_factory.go
+++ b/internals/secrethub/client_factory.go
@@ -63,14 +63,6 @@ func (f *clientFactory) NewClient() (secrethub.ClientInterface, error) {
 		options := f.baseClientOptions()
 		options = append(options, secrethub.WithCredentials(credentialProvider))
 
-		if f.proxyAddress != nil {
-			transport := http.DefaultTransport.(*http.Transport)
-			transport.Proxy = func(request *http.Request) (*url.URL, error) {
-				return f.proxyAddress, nil
-			}
-			options = append(options, secrethub.WithTransport(transport))
-		}
-
 		client, err := secrethub.NewClient(options...)
 		if err == configdir.ErrCredentialNotFound {
 			return nil, ErrCredentialNotExist
@@ -112,6 +104,14 @@ func (f *clientFactory) baseClientOptions() []secrethub.ClientOption {
 			Name:    "secrethub-cli",
 			Version: Version,
 		}),
+	}
+
+	if f.proxyAddress != nil {
+		transport := http.DefaultTransport.(*http.Transport)
+		transport.Proxy = func(request *http.Request) (*url.URL, error) {
+			return f.proxyAddress, nil
+		}
+		options = append(options, secrethub.WithTransport(transport))
 	}
 
 	if f.ServerURL != nil {

--- a/internals/secrethub/client_factory_test.go
+++ b/internals/secrethub/client_factory_test.go
@@ -17,9 +17,14 @@ func TestNewClientFactory_ProxyAddress(t *testing.T) {
 	assert.OK(t, err)
 
 	proxyReceivedRequest := false
-	go http.ListenAndServe(proxyAddress.Hostname()+":"+proxyAddress.Port(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxyReceivedRequest = true
-	}))
+	go func() {
+		err := http.ListenAndServe(proxyAddress.Hostname()+":"+proxyAddress.Port(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proxyReceivedRequest = true
+		}))
+		if err != http.ErrServerClosed && err != nil {
+			t.Errorf("http server error: %s", err)
+		}
+	}()
 
 	// Check if the configuration option takes precedence over the global HTTP_PROXY environment variable
 	os.Setenv("HTTP_PROXY", "http://test.unknown")

--- a/internals/secrethub/client_factory_test.go
+++ b/internals/secrethub/client_factory_test.go
@@ -1,0 +1,46 @@
+package secrethub
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
+
+	"github.com/secrethub/secrethub-cli/internals/cli/ui"
+)
+
+func TestNewClientFactory_ProxyAddress(t *testing.T) {
+	proxyAddress, err := url.Parse("http://127.0.0.1:15555")
+	assert.OK(t, err)
+
+	proxyReceivedRequest := false
+	go http.ListenAndServe(proxyAddress.Hostname()+":"+proxyAddress.Port(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyReceivedRequest = true
+	}))
+
+	// Check if the configuration option takes precedence over the global HTTP_PROXY environment variable
+	os.Setenv("HTTP_PROXY", "http://test.unknown")
+
+	// Make sure the actual API is not reached if proxying fails
+	serverAddress, err := url.Parse("http://test.unknown")
+	assert.OK(t, err)
+
+	io := ui.NewUserIO()
+	store := NewCredentialConfig(io)
+	factory := clientFactory{
+		identityProvider: "key",
+		store:            store,
+		ServerURL:        serverAddress,
+		proxyAddress:     proxyAddress,
+	}
+
+	client, err := factory.NewUnauthenticatedClient()
+	assert.OK(t, err)
+
+	_, _ = client.Users().Create("test", "test@test.test", "test", credentials.CreateKey())
+	assert.OK(t, err)
+	assert.Equal(t, proxyReceivedRequest, true)
+}


### PR DESCRIPTION
Allows a user to set the `SECRETHUB_PROXY_ADDRESS` environment variable or `--proxy-address` flag to configure a proxy used when connecting to the API. It allows for more precise control than just using the `HTTP_PROXY` environment variable because this only affects the SecretHub CLI.