### PR TITLE
Map all secrets from directory to environment variables

### DIFF
--- a/internals/secrethub/env.go
+++ b/internals/secrethub/env.go
@@ -24,5 +24,5 @@ func (cmd *EnvCommand) Register(r command.Registerer) {
 	clause := r.Command("env", "[BETA] Manage environment variables.").Hidden()
 	clause.HelpLong("This command is hidden because it is still in beta. Future versions may break.")
 	NewEnvReadCommand(cmd.io, cmd.newClient).Register(clause)
-	NewEnvListCommand(cmd.io).Register(clause)
+	NewEnvListCommand(cmd.io, cmd.newClient).Register(clause)
 }

--- a/internals/secrethub/env_ls.go
+++ b/internals/secrethub/env_ls.go
@@ -14,10 +14,10 @@ type EnvListCommand struct {
 }
 
 // NewEnvListCommand creates a new EnvListCommand.
-func NewEnvListCommand(io ui.IO, clientFunc newClientFunc) *EnvListCommand {
+func NewEnvListCommand(io ui.IO, newClient newClientFunc) *EnvListCommand {
 	return &EnvListCommand{
 		io:          io,
-		environment: newEnvironment(io, clientFunc),
+		environment: newEnvironment(io, newClient),
 	}
 }
 

--- a/internals/secrethub/env_ls.go
+++ b/internals/secrethub/env_ls.go
@@ -14,10 +14,10 @@ type EnvListCommand struct {
 }
 
 // NewEnvListCommand creates a new EnvListCommand.
-func NewEnvListCommand(io ui.IO) *EnvListCommand {
+func NewEnvListCommand(io ui.IO, clientFunc newClientFunc) *EnvListCommand {
 	return &EnvListCommand{
 		io:          io,
-		environment: newEnvironment(io),
+		environment: newEnvironment(io, clientFunc),
 	}
 }
 

--- a/internals/secrethub/env_read.go
+++ b/internals/secrethub/env_read.go
@@ -20,7 +20,7 @@ func NewEnvReadCommand(io ui.IO, newClient newClientFunc) *EnvReadCommand {
 	return &EnvReadCommand{
 		io:          io,
 		newClient:   newClient,
-		environment: newEnvironment(io),
+		environment: newEnvironment(io, newClient),
 	}
 }
 

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -67,7 +67,7 @@ func (env *environment) register(clause *cli.CommandClause) {
 	clause.Flag("var", "Define the value for a template variable with `VAR=VALUE`, e.g. --var env=prod").Short('v').StringMapVar(&env.templateVars)
 	clause.Flag("template-version", "The template syntax version to be used. The options are v1, v2, latest or auto to automatically detect the version.").Default("auto").StringVar(&env.templateVersion)
 	clause.Flag("no-prompt", "Do not prompt when a template variable is missing and return an error instead.").BoolVar(&env.dontPromptMissingTemplateVar)
-	clause.Flag("secrets-dir", "Path to a directory from which to inject all secrets. The environment variable storing each secret will be the secret's uppercase relative path with '_' instead of the path delimiter.").StringVar(&env.secretsDir)
+	clause.Flag("secrets-dir", "Recursively include all secrets from a directory. Environment variable names are derived from the path of the secret: `/` are replaced with `_` and the name is uppercased.").StringVar(&env.secretsDir)
 	clause.Flag("env", "The name of the environment prepared by the set command (default is `default`)").Default("default").Hidden().StringVar(&env.secretsEnvDir)
 }
 

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -90,6 +90,12 @@ func (env *environment) env() (map[string]value, error) {
 		sources = append(sources, dirSource)
 	}
 
+	// --secrets-dir flag
+	if env.secretsDir != "" {
+		secretsDirEnv := newSecretsDirEnv(env.newClient, env.secretsDir)
+		sources = append(sources, secretsDirEnv)
+	}
+
 	//secrethub.env file
 	if env.envFile == "" {
 		_, err := env.osStat(defaultEnvFile)
@@ -130,12 +136,6 @@ func (env *environment) env() (map[string]value, error) {
 	// secret references (secrethub://)
 	referenceEnv := newReferenceEnv(osEnvMap)
 	sources = append(sources, referenceEnv)
-
-	// --secrets-dir flag
-	if env.secretsDir != "" {
-		secretsDirEnv := newSecretsDirEnv(env.newClient, env.secretsDir)
-		sources = append(sources, secretsDirEnv)
-	}
 
 	// --envar flag
 	// TODO: Validate the flags when parsing by implementing the Flag interface for EnvFlags.

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -194,11 +194,15 @@ func newSecretValue(path string) value {
 	return &secretValue{path: path}
 }
 
+// secretsDirEnv sources environment variables from the directory specified with the --secrets-dir flag.
 type secretsDirEnv struct {
 	clientFunc newClientFunc
 	dirPath    string
 }
 
+// env returns a map of environment variables containing all secrets from the specified path.
+// The variable names are the relative paths of their corresponding secrets in uppercase snake case.
+// An error is returned if two secret paths map to the same variable name.
 func (s *secretsDirEnv) env() (map[string]value, error) {
 	client, err := s.clientFunc()
 	if err != nil {
@@ -236,6 +240,8 @@ func (s *secretsDirEnv) env() (map[string]value, error) {
 	return result, nil
 }
 
+// envVarName returns the environment variable name corresponding to the secret on the specified path
+// by converting the relative path to uppercase snake case.
 func (s *secretsDirEnv) envVarName(path string) string {
 	envVarName := strings.TrimPrefix(path, s.dirPath)
 	envVarName = strings.TrimPrefix(envVarName, "/")

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -24,6 +24,7 @@ import (
 
 type environment struct {
 	io                           ui.IO
+	newClient                    newClientFunc
 	osEnv                        []string
 	readFile                     func(filename string) ([]byte, error)
 	osStat                       func(filename string) (os.FileInfo, error)
@@ -35,9 +36,10 @@ type environment struct {
 	secretsEnvDir                string
 }
 
-func newEnvironment(io ui.IO) *environment {
+func newEnvironment(io ui.IO, newClient newClientFunc) *environment {
 	return &environment{
 		io:           io,
+		newClient:    newClient,
 		osEnv:        os.Environ(),
 		readFile:     ioutil.ReadFile,
 		osStat:       os.Stat,

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -233,7 +233,7 @@ func (s *secretsDirEnv) env() (map[string]value, error) {
 		paths[envVarName] = path
 	}
 
-	result := make(map[string]value, tree.SecretCount())
+	result := make(map[string]value, len(paths))
 	for name, path := range paths {
 		result[name] = newSecretValue(path)
 	}

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -196,15 +196,15 @@ func newSecretValue(path string) value {
 
 // secretsDirEnv sources environment variables from the directory specified with the --secrets-dir flag.
 type secretsDirEnv struct {
-	clientFunc newClientFunc
-	dirPath    string
+	newClient newClientFunc
+	dirPath   string
 }
 
 // env returns a map of environment variables containing all secrets from the specified path.
 // The variable names are the relative paths of their corresponding secrets in uppercase snake case.
 // An error is returned if two secret paths map to the same variable name.
 func (s *secretsDirEnv) env() (map[string]value, error) {
-	client, err := s.clientFunc()
+	client, err := s.newClient()
 	if err != nil {
 		return nil, err
 	}
@@ -250,10 +250,10 @@ func (s *secretsDirEnv) envVarName(path string) string {
 	return envVarName
 }
 
-func newSecretsDirEnv(clientFunc newClientFunc, dirPath string) *secretsDirEnv {
+func newSecretsDirEnv(newClient newClientFunc, dirPath string) *secretsDirEnv {
 	return &secretsDirEnv{
-		clientFunc: clientFunc,
-		dirPath:    dirPath,
+		newClient: newClient,
+		dirPath:   dirPath,
 	}
 }
 

--- a/internals/secrethub/env_source_test.go
+++ b/internals/secrethub/env_source_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestSecretsDirEnv(t *testing.T) {
 	const dirPath = "namespace/repo"
-	testUUID1 := uuid.New()
-	testUUID2 := uuid.New()
-	testUUID3 := uuid.New()
-	testUUID4 := uuid.New()
+	rootDirUUID := uuid.New()
+	subDirUUID := uuid.New()
+	secretUUID1 := uuid.New()
+	secretUUID2 := uuid.New()
 
 	cases := map[string]struct {
 		newClient      newClientFunc
@@ -30,13 +30,13 @@ func TestSecretsDirEnv(t *testing.T) {
 							return &api.Tree{
 								ParentPath: "namespace",
 								RootDir: &api.Dir{
-									DirID: testUUID1,
+									DirID: rootDirUUID,
 									Name:  "repo",
 								},
 								Secrets: map[uuid.UUID]*api.Secret{
-									testUUID2: {
-										SecretID: testUUID2,
-										DirID:    testUUID1,
+									secretUUID1: {
+										SecretID: secretUUID1,
+										DirID:    rootDirUUID,
 										Name:     "foo",
 									},
 								},
@@ -55,20 +55,20 @@ func TestSecretsDirEnv(t *testing.T) {
 							return &api.Tree{
 								ParentPath: "namespace",
 								RootDir: &api.Dir{
-									DirID: testUUID1,
+									DirID: rootDirUUID,
 									Name:  "repo",
 								},
 								Dirs: map[uuid.UUID]*api.Dir{
-									testUUID2: {
-										DirID:    testUUID2,
-										ParentID: &testUUID1,
+									subDirUUID: {
+										DirID:    subDirUUID,
+										ParentID: &rootDirUUID,
 										Name:     "foo",
 									},
 								},
 								Secrets: map[uuid.UUID]*api.Secret{
-									testUUID3: {
-										SecretID: testUUID3,
-										DirID:    testUUID2,
+									secretUUID1: {
+										SecretID: secretUUID1,
+										DirID:    subDirUUID,
 										Name:     "bar",
 									},
 								},
@@ -87,25 +87,25 @@ func TestSecretsDirEnv(t *testing.T) {
 							return &api.Tree{
 								ParentPath: "namespace",
 								RootDir: &api.Dir{
-									DirID: testUUID1,
+									DirID: rootDirUUID,
 									Name:  "repo",
 								},
 								Dirs: map[uuid.UUID]*api.Dir{
-									testUUID2: {
-										DirID:    testUUID2,
-										ParentID: &testUUID1,
+									subDirUUID: {
+										DirID:    subDirUUID,
+										ParentID: &rootDirUUID,
 										Name:     "foo",
 									},
 								},
 								Secrets: map[uuid.UUID]*api.Secret{
-									testUUID3: {
-										SecretID: testUUID3,
-										DirID:    testUUID2,
+									secretUUID1: {
+										SecretID: secretUUID1,
+										DirID:    subDirUUID,
 										Name:     "bar",
 									},
-									testUUID4: {
-										SecretID: testUUID4,
-										DirID:    testUUID1,
+									secretUUID2: {
+										SecretID: secretUUID2,
+										DirID:    rootDirUUID,
 										Name:     "foo_bar",
 									},
 								},

--- a/internals/secrethub/env_source_test.go
+++ b/internals/secrethub/env_source_test.go
@@ -33,6 +33,31 @@ func TestSecretsDirEnv(t *testing.T) {
 									DirID: testUUID1,
 									Name:  "repo",
 								},
+								Secrets: map[uuid.UUID]*api.Secret{
+									testUUID2: {
+										SecretID: testUUID2,
+										DirID:    testUUID1,
+										Name:     "foo",
+									},
+								},
+							}, nil
+						},
+					},
+				}, nil
+			},
+			expectedValues: []string{"FOO"},
+		},
+		"success secret in dir": {
+			clientFunc: func() (secrethub.ClientInterface, error) {
+				return fakeclient.Client{
+					DirService: &fakeclient.DirService{
+						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
+							return &api.Tree{
+								ParentPath: "namespace",
+								RootDir: &api.Dir{
+									DirID: testUUID1,
+									Name:  "repo",
+								},
 								Dirs: map[uuid.UUID]*api.Dir{
 									testUUID2: {
 										DirID:    testUUID2,

--- a/internals/secrethub/env_source_test.go
+++ b/internals/secrethub/env_source_test.go
@@ -1,0 +1,117 @@
+package secrethub
+
+import (
+	"testing"
+
+	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
+	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/fakeclient"
+)
+
+func TestSecretsDirEnv(t *testing.T) {
+	const dirPath = "namespace/repo"
+	testUUID1 := uuid.New()
+	testUUID2 := uuid.New()
+	testUUID3 := uuid.New()
+	testUUID4 := uuid.New()
+
+	cases := map[string]struct {
+		clientFunc     newClientFunc
+		expectedValues []string
+		err            error
+	}{
+		"success": {
+			clientFunc: func() (secrethub.ClientInterface, error) {
+				return fakeclient.Client{
+					DirService: &fakeclient.DirService{
+						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
+							return &api.Tree{
+								ParentPath: "namespace",
+								RootDir: &api.Dir{
+									DirID: testUUID1,
+									Name:  "repo",
+								},
+								Dirs: map[uuid.UUID]*api.Dir{
+									testUUID2: {
+										DirID:    testUUID2,
+										ParentID: &testUUID1,
+										Name:     "foo",
+									},
+								},
+								Secrets: map[uuid.UUID]*api.Secret{
+									testUUID3: {
+										SecretID: testUUID3,
+										DirID:    testUUID2,
+										Name:     "bar",
+									},
+								},
+							}, nil
+						},
+					},
+				}, nil
+			},
+			expectedValues: []string{"FOO_BAR"},
+		},
+		"name collision": {
+			clientFunc: func() (secrethub.ClientInterface, error) {
+				return fakeclient.Client{
+					DirService: &fakeclient.DirService{
+						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
+							return &api.Tree{
+								ParentPath: "namespace",
+								RootDir: &api.Dir{
+									DirID: testUUID1,
+									Name:  "repo",
+								},
+								Dirs: map[uuid.UUID]*api.Dir{
+									testUUID2: {
+										DirID:    testUUID2,
+										ParentID: &testUUID1,
+										Name:     "foo",
+									},
+								},
+								Secrets: map[uuid.UUID]*api.Secret{
+									testUUID3: {
+										SecretID: testUUID3,
+										DirID:    testUUID2,
+										Name:     "bar",
+									},
+									testUUID4: {
+										SecretID: testUUID4,
+										DirID:    testUUID1,
+										Name:     "foo_bar",
+									},
+								},
+							}, nil
+						},
+					},
+				}, nil
+			},
+			err: errNameCollision{
+				name:       "FOO_BAR",
+				firstPath:  "namespace/repo/foo/bar",
+				secondPath: "namespace/repo/foo_bar",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			source := newSecretsDirEnv(tc.clientFunc, dirPath)
+			secrets, err := source.env()
+			if tc.err != nil && err != nil {
+				assert.Equal(t, err, tc.err)
+			} else {
+				assert.OK(t, err)
+				assert.Equal(t, len(secrets), len(tc.expectedValues))
+				for _, name := range tc.expectedValues {
+					if _, ok := secrets[name]; !ok {
+						t.Errorf("expected but not found env var with name: %s", name)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internals/secrethub/env_source_test.go
+++ b/internals/secrethub/env_source_test.go
@@ -101,7 +101,7 @@ func TestSecretsDirEnv(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			source := newSecretsDirEnv(tc.clientFunc, dirPath)
 			secrets, err := source.env()
-			if tc.err != nil && err != nil {
+			if tc.err != nil {
 				assert.Equal(t, err, tc.err)
 			} else {
 				assert.OK(t, err)

--- a/internals/secrethub/env_source_test.go
+++ b/internals/secrethub/env_source_test.go
@@ -18,12 +18,12 @@ func TestSecretsDirEnv(t *testing.T) {
 	testUUID4 := uuid.New()
 
 	cases := map[string]struct {
-		clientFunc     newClientFunc
+		newClient      newClientFunc
 		expectedValues []string
 		err            error
 	}{
 		"success": {
-			clientFunc: func() (secrethub.ClientInterface, error) {
+			newClient: func() (secrethub.ClientInterface, error) {
 				return fakeclient.Client{
 					DirService: &fakeclient.DirService{
 						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
@@ -48,7 +48,7 @@ func TestSecretsDirEnv(t *testing.T) {
 			expectedValues: []string{"FOO"},
 		},
 		"success secret in dir": {
-			clientFunc: func() (secrethub.ClientInterface, error) {
+			newClient: func() (secrethub.ClientInterface, error) {
 				return fakeclient.Client{
 					DirService: &fakeclient.DirService{
 						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
@@ -80,7 +80,7 @@ func TestSecretsDirEnv(t *testing.T) {
 			expectedValues: []string{"FOO_BAR"},
 		},
 		"name collision": {
-			clientFunc: func() (secrethub.ClientInterface, error) {
+			newClient: func() (secrethub.ClientInterface, error) {
 				return fakeclient.Client{
 					DirService: &fakeclient.DirService{
 						GetTreeFunc: func(path string, depth int, ancestors bool) (*api.Tree, error) {
@@ -124,7 +124,7 @@ func TestSecretsDirEnv(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			source := newSecretsDirEnv(tc.clientFunc, dirPath)
+			source := newSecretsDirEnv(tc.newClient, dirPath)
 			secrets, err := source.env()
 			if tc.err != nil {
 				assert.Equal(t, err, tc.err)

--- a/internals/secrethub/run.go
+++ b/internals/secrethub/run.go
@@ -63,7 +63,7 @@ func NewRunCommand(io ui.IO, newClient newClientFunc) *RunCommand {
 	return &RunCommand{
 		io:          io,
 		osEnv:       os.Environ(),
-		environment: newEnvironment(io),
+		environment: newEnvironment(io, newClient),
 		newClient:   newClient,
 	}
 }

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -662,6 +662,8 @@ func TestRunCommand_environment(t *testing.T) {
 	rootDirUUID := uuid.New()
 	secretUUID := uuid.New()
 
+	const secretPathFoo = "namespace/repo/foo"
+
 	cases := map[string]struct {
 		command         RunCommand
 		expectedEnv     []string
@@ -806,7 +808,7 @@ func TestRunCommand_environment(t *testing.T) {
 						SecretService: &fakeclient.SecretService{
 							VersionService: &fakeclient.SecretVersionService{
 								GetWithDataFunc: func(path string) (*api.SecretVersion, error) {
-									if path == "namespace/repo/foo" {
+									if path == secretPathFoo {
 										return &api.SecretVersion{Data: []byte("aaa")}, nil
 									} else if path == "other/secret/path" {
 										return &api.SecretVersion{Data: []byte("bbb")}, nil
@@ -857,7 +859,7 @@ func TestRunCommand_environment(t *testing.T) {
 						SecretService: &fakeclient.SecretService{
 							VersionService: &fakeclient.SecretVersionService{
 								GetWithDataFunc: func(path string) (*api.SecretVersion, error) {
-									if path == "namespace/repo/foo" {
+									if path == secretPathFoo {
 										return &api.SecretVersion{Data: []byte("aaa")}, nil
 									}
 									return nil, api.ErrSecretNotFound
@@ -909,7 +911,7 @@ func TestRunCommand_environment(t *testing.T) {
 								GetWithDataFunc: func(path string) (*api.SecretVersion, error) {
 									if path == "test/test/test" {
 										return &api.SecretVersion{Data: []byte("bbb")}, nil
-									} else if path == "namespace/repo/foo" {
+									} else if path == secretPathFoo {
 										return &api.SecretVersion{Data: []byte("aaa")}, nil
 									}
 									return nil, api.ErrSecretNotFound

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -770,7 +770,7 @@ func TestRunCommand_environment(t *testing.T) {
 			expectedEnv:     []string{"TEST=bbb"},
 		},
 		// TODO Add test case for: envar flag has precedence over secret reference - requires refactoring of fakeclient
-		"secrets-dir flag has precedence over secret reference": {
+		"secret reference has precedence over secrets-dir flag": {
 			command: RunCommand{
 				environment: &environment{
 					newClient: func() (secrethub.ClientInterface, error) {
@@ -818,8 +818,8 @@ func TestRunCommand_environment(t *testing.T) {
 					}, nil
 				},
 			},
-			expectedSecrets: []string{"aaa"},
-			expectedEnv:     []string{"FOO=aaa"},
+			expectedSecrets: []string{"bbb"},
+			expectedEnv:     []string{"FOO=bbb"},
 		},
 		"secret reference has precedence over .env file": {
 			command: RunCommand{

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -659,8 +659,8 @@ func osStatFunc(name string, err error) func(string) (os.FileInfo, error) {
 }
 
 func TestRunCommand_environment(t *testing.T) {
-	testUUID1 := uuid.New()
-	testUUID2 := uuid.New()
+	rootDirUUID := uuid.New()
+	secretUUID := uuid.New()
 
 	cases := map[string]struct {
 		command         RunCommand
@@ -779,13 +779,13 @@ func TestRunCommand_environment(t *testing.T) {
 									return &api.Tree{
 										ParentPath: "namespace",
 										RootDir: &api.Dir{
-											DirID: testUUID1,
+											DirID: rootDirUUID,
 											Name:  "repo",
 										},
 										Secrets: map[uuid.UUID]*api.Secret{
-											testUUID2: {
-												SecretID: testUUID2,
-												DirID:    testUUID1,
+											secretUUID: {
+												SecretID: secretUUID,
+												DirID:    rootDirUUID,
 												Name:     "foo",
 											},
 										},
@@ -831,13 +831,13 @@ func TestRunCommand_environment(t *testing.T) {
 									return &api.Tree{
 										ParentPath: "namespace",
 										RootDir: &api.Dir{
-											DirID: testUUID1,
+											DirID: rootDirUUID,
 											Name:  "repo",
 										},
 										Secrets: map[uuid.UUID]*api.Secret{
-											testUUID2: {
-												SecretID: testUUID2,
-												DirID:    testUUID1,
+											secretUUID: {
+												SecretID: secretUUID,
+												DirID:    rootDirUUID,
 												Name:     "foo",
 											},
 										},
@@ -881,13 +881,13 @@ func TestRunCommand_environment(t *testing.T) {
 									return &api.Tree{
 										ParentPath: "namespace",
 										RootDir: &api.Dir{
-											DirID: testUUID1,
+											DirID: rootDirUUID,
 											Name:  "repo",
 										},
 										Secrets: map[uuid.UUID]*api.Secret{
-											testUUID2: {
-												SecretID: testUUID2,
-												DirID:    testUUID1,
+											secretUUID: {
+												SecretID: secretUUID,
+												DirID:    rootDirUUID,
 												Name:     "foo",
 											},
 										},


### PR DESCRIPTION
This PR adds the feature of passing all secrets under a given path to the child process of the run command. This path can be specified with the `--secrets-dir` flag.

I took the following decisions:
1. Environment variables set by this flag have priority over os environment variables, but have a lower precedence than the ones set through `.env` files.

2. In case of name collisions such as when there is a secret under the path: 
`namespace/repo/dir/db_username`
and one under the path:
`namespace/repo/dir/db/username`,
an error will be returned.
This was done because spotting such a name conflict can be difficult and choosing one value over the other can lead to unexpected results.

The naming collision error message and the help text of the flag might need some tweaking.