### PR TITLE
Move taken service account error to server

### DIFF
--- a/internals/secrethub/service_aws_init.go
+++ b/internals/secrethub/service_aws_init.go
@@ -26,7 +26,6 @@ import (
 // Errors
 var (
 	ErrInvalidAWSRegion      = errMain.Code("invalid_region").Error("invalid AWS region")
-	ErrRoleAlreadyTaken      = errMain.Code("role_taken").Error("a service account with that IAM role already exists. Use the existing service account by assuming the role and passing the --identity-provider=aws flag. Or create a new service account with a different IAM role.")
 	ErrInvalidPermissionPath = errMain.Code("invalid_permission_path").ErrorPref("invalid permission path: %s")
 	ErrMissingRegion         = errMain.Code("missing_region").Error("could not find AWS region. Supply using the --region flag or in the AWS configuration. See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html for the AWS configuration files")
 )
@@ -136,9 +135,7 @@ func (cmd *ServiceAWSInitCommand) Run() error {
 	}
 
 	service, err := client.Services().Create(cmd.repo.Value(), cmd.description, credentials.CreateAWS(cmd.kmsKeyID, cmd.role, cfg))
-	if err == api.ErrCredentialAlreadyExists {
-		return ErrRoleAlreadyTaken
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 

--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -128,9 +128,7 @@ func (cmd *ServiceGCPInitCommand) Run() error {
 	}
 
 	service, err := client.Services().Create(cmd.repo.Value(), cmd.description, credentials.CreateGCPServiceAccount(cmd.serviceAccountEmail, cmd.kmsKeyResourceID))
-	if err == api.ErrCredentialAlreadyExists {
-		return ErrRoleAlreadyTaken
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, when a service account for AWS or GCP cannot be created because the role/email has already been taken, the server returns a generic `ErrCredentialAlreadyExists` and the error gets converted to a more helpful error on the CLI-side.

This PR moves this responsibility to the server, so the error is nice and consistent in the other SecretHub clients too.