### PR TITLE
Directly check if repo exists

### DIFF
--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -48,6 +48,11 @@ func (cmd *ServiceGCPInitCommand) Run() error {
 		return err
 	}
 
+	_, err = client.Repos().Get(cmd.repo.String())
+	if err != nil {
+		return err
+	}
+
 	if cmd.serviceAccountEmail == "" && cmd.kmsKeyResourceID == "" {
 		fmt.Fprintln(cmd.io.Stdout(), "This command creates a new service account for use on GCP. For help on this, run `secrethub service gcp init --help`.")
 

--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -48,6 +48,7 @@ func (cmd *ServiceGCPInitCommand) Run() error {
 		return err
 	}
 
+	// Fail fast if the repo does not exist.
 	_, err = client.Repos().Get(cmd.repo.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
This avoids an annoying error at the end if the repo does not exist.