### PR TITLE
Do not accept a directory as argument to service init

### DIFF
--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -105,7 +105,7 @@ func (cmd *ServiceInitCommand) Run() error {
 // Register registers the command, arguments and flags on the provided Registerer.
 func (cmd *ServiceInitCommand) Register(r command.Registerer) {
 	clause := r.Command("init", "Create a new service account.")
-	clause.Arg("repo", "The service account is attached to the repository in this path.").Required().PlaceHolder(repoPathPlaceHolder).SetValue(&cmd.path)
+	clause.Arg("repo", "The service account is attached to the repository in this path.").Required().PlaceHolder(repoPathPlaceHolder).SetValue(&cmd.repo)
 	clause.Flag("description", "A description for the service so others will recognize it.").StringVar(&cmd.description)
 	clause.Flag("descr", "").Hidden().StringVar(&cmd.description)
 	clause.Flag("desc", "").Hidden().StringVar(&cmd.description)

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -23,7 +23,7 @@ type ServiceInitCommand struct {
 	description string
 	file        string
 	fileMode    filemode.FileMode
-	path        api.DirPath
+	repo        api.RepoPath
 	permission  string
 	clipper     clip.Clipper
 	io          ui.IO
@@ -54,25 +54,19 @@ func (cmd *ServiceInitCommand) Run() error {
 		return ErrFlagsConflict("--clip and --file")
 	}
 
-	repo := cmd.path.GetRepoPath()
-
 	client, err := cmd.newClient()
 	if err != nil {
 		return err
 	}
 
 	credential := credentials.CreateKey()
-	service, err := client.Services().Create(repo.Value(), cmd.description, credential)
+	service, err := client.Services().Create(cmd.repo.Value(), cmd.description, credential)
 	if err != nil {
 		return err
 	}
 
-	if strings.Contains(cmd.permission, ":") && !cmd.path.IsRepoPath() {
-		return api.ErrInvalidRepoPath(cmd.path)
-	}
-
 	if cmd.permission != "" {
-		err = givePermission(service, cmd.path.GetRepoPath(), cmd.permission, client)
+		err = givePermission(service, cmd.repo, cmd.permission, client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Just like we already do for `service aws init`, don't accept a directory as argument of the command. Instead, if you want to set a permission on a subdirectory, you should use the `--permission` flag.