### PR TITLE
Only list user-managed GCP Service Accounts in service gcp init prompt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/secrethub/demo-app v0.1.0
-	github.com/secrethub/secrethub-go v0.29.1-0.20200703150346-411544a71e9d
+	github.com/secrethub/secrethub-go v0.29.1-0.20200707154958-5e5602145597
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/secrethub/secrethub-go v0.29.1-0.20200703092019-9f5d3de9b0e4 h1:TszZ+
 github.com/secrethub/secrethub-go v0.29.1-0.20200703092019-9f5d3de9b0e4/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
 github.com/secrethub/secrethub-go v0.29.1-0.20200703150346-411544a71e9d h1:tADItWP+YXaGLD1ZMFocxDaKKVcu8wXgEulbcUmX4Ec=
 github.com/secrethub/secrethub-go v0.29.1-0.20200703150346-411544a71e9d/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
+github.com/secrethub/secrethub-go v0.29.1-0.20200707154958-5e5602145597 h1:uC9ODMKaqBo1k8fxmFSWGkLr05TgEd3t4mHqJ8Jo9Gc=
+github.com/secrethub/secrethub-go v0.29.1-0.20200707154958-5e5602145597/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -68,7 +68,7 @@ func (cmd *ServiceGCPInitCommand) Run() error {
 		serviceAccountLister := gcpServiceAccountOptionLister{
 			ProjectID: projectID,
 		}
-		serviceAccountEmail, err := ui.ChooseDynamicOptionsValidate(cmd.io, "What is the email of the service account you want to use?", serviceAccountLister.Options, "service account", api.ValidateGCPServiceAccountEmail)
+		serviceAccountEmail, err := ui.ChooseDynamicOptionsValidate(cmd.io, "What is the email of the service account you want to use?", serviceAccountLister.Options, "service account", api.ValidateGCPUserManagedServiceAccountEmail)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (cmd *ServiceGCPInitCommand) Run() error {
 	}
 
 	if cmd.serviceAccountEmail == "" {
-		serviceAccountEmail, err := ui.AskAndValidate(cmd.io, "What is the email of the GCP Service Account that should have access to the service?\n", 3, api.ValidateGCPServiceAccountEmail)
+		serviceAccountEmail, err := ui.AskAndValidate(cmd.io, "What is the email of the GCP Service Account that should have access to the service?\n", 3, api.ValidateGCPUserManagedServiceAccountEmail)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,8 @@ func (l *gcpServiceAccountOptionLister) Options() ([]ui.Option, bool, error) {
 
 	options := make([]ui.Option, 0, len(resp.Accounts))
 	for _, account := range resp.Accounts {
-		if err := api.ValidateGCPServiceAccountEmail(account.Email); err != nil {
+		// Only list user-managed service accounts
+		if err := api.ValidateGCPUserManagedServiceAccountEmail(account.Email); err != nil {
 			continue
 		}
 		display := account.Email

--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -216,7 +216,7 @@ func (l *gcpServiceAccountOptionLister) Options() ([]ui.Option, bool, error) {
 		return nil, false, gcp.HandleError(err)
 	}
 
-	var options []ui.Option
+	options := make([]ui.Option, 0, len(resp.Accounts))
 	for _, account := range resp.Accounts {
 		if err := api.ValidateGCPServiceAccountEmail(account.Email); err != nil {
 			continue

--- a/internals/secrethub/service_gcp_init.go
+++ b/internals/secrethub/service_gcp_init.go
@@ -216,16 +216,19 @@ func (l *gcpServiceAccountOptionLister) Options() ([]ui.Option, bool, error) {
 		return nil, false, gcp.HandleError(err)
 	}
 
-	options := make([]ui.Option, len(resp.Accounts))
-	for i, account := range resp.Accounts {
+	var options []ui.Option
+	for _, account := range resp.Accounts {
+		if err := api.ValidateGCPServiceAccountEmail(account.Email); err != nil {
+			continue
+		}
 		display := account.Email
 		if account.Description != "" {
 			display += " (" + account.Description + ")"
 		}
-		options[i] = ui.Option{
+		options = append(options, ui.Option{
 			Value:   account.Email,
 			Display: display,
-		}
+		})
 	}
 
 	l.nextPage = resp.NextPageToken


### PR DESCRIPTION
Other Service Accounts are not supported anyway, so no reason to list them.