### PR TITLE
Add `-f`, `-i` and `--noreport` flags to tree command

### DIFF
--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -109,10 +109,10 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 
 		if i == total-1 {
 			fmt.Fprintf(w, format[0], prefix, prevPath, name)
-			cmd.printDirContentsRecursively(sub, prefix+format[2], w, format, prevPath + name.(string))
+			cmd.printDirContentsRecursively(sub, prefix+format[2], w, format, prevPath+name.(string))
 		} else {
 			fmt.Fprintf(w, format[1], prefix, prevPath, name)
-			cmd.printDirContentsRecursively(sub, prefix+format[3], w, format, prevPath + name.(string))
+			cmd.printDirContentsRecursively(sub, prefix+format[3], w, format, prevPath+name.(string))
 		}
 		i++
 	}

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -88,12 +88,6 @@ func (cmd *TreeCommand) printTree(t *api.Tree, w io.Writer) {
 // in a tree-like structure, subdirs first followed by secrets.
 func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string, w io.Writer, prevPath string) {
 
-	const (
-		format1 = "%s\n"
-		format2 = "%s└── %s\n"
-		format3 = "%s├── %s\n"
-	)
-
 	sort.Sort(api.SortDirByName(dir.SubDirs))
 	sort.Sort(api.SortSecretByName(dir.Secrets))
 
@@ -115,13 +109,13 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 		colorName := colorizeByStatus(sub.Status, name+"/")
 
 		if cmd.noIndentation {
-			fmt.Fprintf(w, format1, colorName)
+			fmt.Fprintf(w, "%s\n", colorName)
 			cmd.printDirContentsRecursively(sub, prefix, w, name)
 		} else if i == total-1 {
-			fmt.Fprintf(w, format2, prefix, colorName)
+			fmt.Fprintf(w, "%s└── %s\n", prefix, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+"    ", w, name)
 		} else {
-			fmt.Fprintf(w, format3, prefix, colorName)
+			fmt.Fprintf(w, "%s├── %s\n", prefix, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+"│   ", w, name)
 		}
 		i++
@@ -135,11 +129,11 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 		colorName := colorizeByStatus(secret.Status, name)
 
 		if cmd.noIndentation {
-			fmt.Fprintf(w, format1, colorName)
+			fmt.Fprintf(w, "%s\n", colorName)
 		} else if i == total-1 {
-			fmt.Fprintf(w, format2, prefix, colorName)
+			fmt.Fprintf(w, "%s└── %s\n", prefix, colorName)
 		} else {
-			fmt.Fprintf(w, format3, prefix, colorName)
+			fmt.Fprintf(w, "%s├── %s\n", prefix, colorName)
 		}
 		i++
 	}

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -114,14 +114,13 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 	i := 0
 	for _, sub := range dir.SubDirs {
 		colorName := colorizeByStatus(sub.Status, sub.Name)
-		colorPrefix := colorizeByStatus(sub.Status, prefix)
 		colorPrevPath := colorizeByStatus(sub.Status, prevPath)
 
 		if i == total-1 {
-			fmt.Fprintf(w, format[0], colorPrefix, colorPrevPath, colorName)
+			fmt.Fprintf(w, format[0], prefix, colorPrevPath, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+format[2], w, format, prevPath+sub.Name)
 		} else {
-			fmt.Fprintf(w, format[1], colorPrefix, colorPrevPath, colorName)
+			fmt.Fprintf(w, format[1], prefix, colorPrevPath, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+format[3], w, format, prevPath+sub.Name)
 		}
 		i++
@@ -129,13 +128,12 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 
 	for _, secret := range dir.Secrets {
 		colorName := colorizeByStatus(secret.Status, secret.Name)
-		colorPrefix := colorizeByStatus(secret.Status, prefix)
 		colorPrevPath := colorizeByStatus(secret.Status, prevPath)
 
 		if i == total-1 {
-			fmt.Fprintf(w, format[0], colorPrefix, colorPrevPath, colorName)
+			fmt.Fprintf(w, format[0], prefix, colorPrevPath, colorName)
 		} else {
-			fmt.Fprintf(w, format[1], colorPrefix, colorPrevPath, colorName)
+			fmt.Fprintf(w, format[1], prefix, colorPrevPath, colorName)
 		}
 		i++
 	}

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -50,10 +50,10 @@ func (cmd *TreeCommand) Register(r command.Registerer) {
 	clause := r.Command("tree", "List contents of a directory in a tree-like format.")
 	clause.Arg("dir-path", "The path to to show contents for").Required().PlaceHolder(optionalDirPathPlaceHolder).SetValue(&cmd.path)
 
-	clause.Flag("full-paths", "Print the full paths of the directories and secrets.").Short('f').BoolVar(&cmd.fullPaths)
-	clause.Flag("no-indentation", "Print the content without indentation.").Short('i').BoolVar(&cmd.noIndentation)
-	clause.Flag("no-report", "Skip the report at the bottom.").BoolVar(&cmd.noReport)
-	clause.Flag("noreport", "Skip the report at the bottom.").BoolVar(&cmd.noReport)
+	clause.Flag("full-paths", "Print the full path of each directory and secret.").Short('f').BoolVar(&cmd.fullPaths)
+	clause.Flag("no-indentation", "Don't print indentation lines.").Short('i').BoolVar(&cmd.noIndentation)
+	clause.Flag("no-report", "Turn off secret/directory count at end of tree listing.").BoolVar(&cmd.noReport)
+	clause.Flag("noreport", "Turn off secret/directory count at end of tree listing.").Hidden().BoolVar(&cmd.noReport)
 
 	command.BindAction(clause, cmd.Run)
 }

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -88,6 +88,12 @@ func (cmd *TreeCommand) printTree(t *api.Tree, w io.Writer) {
 // in a tree-like structure, subdirs first followed by secrets.
 func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string, w io.Writer, prevPath string) {
 
+	const (
+		format1 = "%s\n"
+		format2 = "%s└── %s\n"
+		format3 = "%s├── %s\n"
+	)
+
 	sort.Sort(api.SortDirByName(dir.SubDirs))
 	sort.Sort(api.SortSecretByName(dir.Secrets))
 
@@ -106,16 +112,16 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 		if cmd.fullPaths {
 			name = prevPath + name
 		}
-		colorName := colorizeByStatus(sub.Status, name)
+		colorName := colorizeByStatus(sub.Status, name + "/")
 
 		if cmd.noIndentation {
-			fmt.Fprintf(w, "%s/\n", colorName)
+			fmt.Fprintf(w, format1, colorName)
 			cmd.printDirContentsRecursively(sub, prefix, w, name)
 		} else if i == total-1 {
-			fmt.Fprintf(w, "%s└── %s/\n", prefix, colorName)
+			fmt.Fprintf(w, format2, prefix, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+"    ", w, name)
 		} else {
-			fmt.Fprintf(w, "%s├── %s/\n", prefix, colorName)
+			fmt.Fprintf(w, format3, prefix, colorName)
 			cmd.printDirContentsRecursively(sub, prefix+"│   ", w, name)
 		}
 		i++
@@ -129,11 +135,11 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 		colorName := colorizeByStatus(secret.Status, name)
 
 		if cmd.noIndentation {
-			fmt.Fprintf(w, "%s\n", colorName)
+			fmt.Fprintf(w, format1, colorName)
 		} else if i == total-1 {
-			fmt.Fprintf(w, "%s└── %s\n", prefix, colorName)
+			fmt.Fprintf(w, format2, prefix, colorName)
 		} else {
-			fmt.Fprintf(w, "%s├── %s\n", prefix, colorName)
+			fmt.Fprintf(w, format3, prefix, colorName)
 		}
 		i++
 	}

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -113,10 +113,10 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 			cmd.printDirContentsRecursively(sub, prefix, w, name)
 		} else if i == total-1 {
 			fmt.Fprintf(w, "%s└── %s/\n", prefix, colorName)
-			cmd.printDirContentsRecursively(sub, prefix + "    ", w, name)
+			cmd.printDirContentsRecursively(sub, prefix+"    ", w, name)
 		} else {
 			fmt.Fprintf(w, "%s├── %s/\n", prefix, colorName)
-			cmd.printDirContentsRecursively(sub, prefix + "│   ", w, name)
+			cmd.printDirContentsRecursively(sub, prefix+"│   ", w, name)
 		}
 		i++
 	}

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -112,7 +112,7 @@ func (cmd *TreeCommand) printDirContentsRecursively(dir *api.Dir, prefix string,
 		if cmd.fullPaths {
 			name = prevPath + name
 		}
-		colorName := colorizeByStatus(sub.Status, name + "/")
+		colorName := colorizeByStatus(sub.Status, name+"/")
 
 		if cmd.noIndentation {
 			fmt.Fprintf(w, format1, colorName)

--- a/internals/secrethub/tree.go
+++ b/internals/secrethub/tree.go
@@ -13,9 +13,12 @@ import (
 
 // TreeCommand lists the contents of a directory at a given path in a tree-like format.
 type TreeCommand struct {
-	path      api.DirPath
-	io        ui.IO
-	newClient newClientFunc
+	path          api.DirPath
+	io            ui.IO
+	fullPaths     bool
+	noIndentation bool
+	noReport      bool
+	newClient     newClientFunc
 }
 
 // NewTreeCommand creates a new TreeCommand.

--- a/internals/secrethub/tree_test.go
+++ b/internals/secrethub/tree_test.go
@@ -2,9 +2,9 @@ package secrethub
 
 import (
 	"bytes"
-	"github.com/fatih/color"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 	"github.com/secrethub/secrethub-go/internals/api"
 	"github.com/secrethub/secrethub-go/internals/api/uuid"

--- a/internals/secrethub/tree_test.go
+++ b/internals/secrethub/tree_test.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"bytes"
+	"github.com/fatih/color"
 	"testing"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
@@ -138,13 +139,14 @@ func TestSimpleTree(t *testing.T) {
 }
 
 func TestTreeColoring(t *testing.T) {
+	color.NoColor = false
 	uuid0, _ := uuid.FromString("0")
 	uuid1, _ := uuid.FromString("1")
 	uuid2, _ := uuid.FromString("2")
 	tree := &api.Tree{
 		RootDir: &api.Dir{
 			Name:   "test/repo",
-			Status: "flagged",
+			Status: api.StatusFlagged,
 			DirID:  uuid0,
 			SubDirs: []*api.Dir{
 				{
@@ -156,11 +158,11 @@ func TestTreeColoring(t *testing.T) {
 					Name:     "secretFolder",
 					DirID:    uuid2,
 					ParentID: &uuid0,
-					Status:   "flagged",
+					Status:   api.StatusFlagged,
 					Secrets: []*api.Secret{
 						{
 							Name:   "found you",
-							Status: "flagged",
+							Status: api.StatusFlagged,
 						},
 					},
 				},
@@ -203,10 +205,10 @@ func TestTreeColoring(t *testing.T) {
 					return &secrethub.Client{}, nil
 				},
 			},
-			expectedOutput: "test/repo/\n" +
+			expectedOutput: red.Sprint("test/repo/") + "\n" +
 				"├── happy/\n" +
-				"├── secretFolder/\n" +
-				"│   └── found you\n" +
+				"├── " + red.Sprint("secretFolder/") + "\n" +
+				"│   └── " + red.Sprint("found you") + "\n" +
 				"└── mySecret\n\n" +
 				"2 directories, 2 secrets\n",
 		},
@@ -218,10 +220,10 @@ func TestTreeColoring(t *testing.T) {
 					return &secrethub.Client{}, nil
 				},
 			},
-			expectedOutput: "test/repo/\n" +
+			expectedOutput: red.Sprint("test/repo/") + "\n" +
 				"├── test/repo/happy/\n" +
-				"├── test/repo/secretFolder/\n" +
-				"│   └── test/repo/secretFolder/found you\n" +
+				"├── " + red.Sprint("test/repo/secretFolder/") + "\n" +
+				"│   └── " + red.Sprint("test/repo/secretFolder/found you") + "\n" +
 				"└── test/repo/mySecret\n\n" +
 				"2 directories, 2 secrets\n",
 		},

--- a/internals/secrethub/tree_test.go
+++ b/internals/secrethub/tree_test.go
@@ -14,20 +14,14 @@ import (
 func TestSimpleTree(t *testing.T) {
 	uuid0, _ := uuid.FromString("0")
 	uuid1, _ := uuid.FromString("1")
-	uuid2, _ := uuid.FromString("2")
 	tree := &api.Tree{
 		RootDir: &api.Dir{
 			Name:  "test/repo",
 			DirID: uuid0,
 			SubDirs: []*api.Dir{
 				{
-					Name:     "happy",
-					DirID:    uuid1,
-					ParentID: &uuid0,
-				},
-				{
 					Name:     "secretFolder",
-					DirID:    uuid2,
+					DirID:    uuid1,
 					ParentID: &uuid0,
 					Secrets: []*api.Secret{
 						{Name: "found you"},
@@ -44,13 +38,8 @@ func TestSimpleTree(t *testing.T) {
 				ParentID: &uuid0,
 			},
 			uuid.New(): {
-				Name:     "happy",
-				DirID:    uuid1,
-				ParentID: &uuid0,
-			},
-			uuid.New(): {
 				Name:     "secretFolder",
-				DirID:    uuid2,
+				DirID:    uuid1,
 				ParentID: &uuid0,
 				Secrets: []*api.Secret{
 					{Name: "found you"},
@@ -74,11 +63,10 @@ func TestSimpleTree(t *testing.T) {
 				},
 			},
 			expectedOutput: "test/repo/\n" +
-				"├── happy/\n" +
 				"├── secretFolder/\n" +
 				"│   └── found you\n" +
 				"└── mySecret\n\n" +
-				"2 directories, 2 secrets\n",
+				"1 directory, 2 secrets\n",
 		},
 		"full path": {
 			cmd: &TreeCommand{
@@ -90,11 +78,10 @@ func TestSimpleTree(t *testing.T) {
 				},
 			},
 			expectedOutput: "test/repo/\n" +
-				"├── test/repo/happy/\n" +
 				"├── test/repo/secretFolder/\n" +
 				"│   └── test/repo/secretFolder/found you\n" +
 				"└── test/repo/mySecret\n\n" +
-				"2 directories, 2 secrets\n",
+				"1 directory, 2 secrets\n",
 		},
 		"no indent": {
 			cmd: &TreeCommand{
@@ -105,11 +92,10 @@ func TestSimpleTree(t *testing.T) {
 				},
 			},
 			expectedOutput: "test/repo/\n" +
-				"happy/\n" +
 				"secretFolder/\n" +
 				"found you\n" +
 				"mySecret\n\n" +
-				"2 directories, 2 secrets\n",
+				"1 directory, 2 secrets\n",
 		},
 		"no report": {
 			cmd: &TreeCommand{
@@ -120,7 +106,6 @@ func TestSimpleTree(t *testing.T) {
 				},
 			},
 			expectedOutput: "test/repo/\n" +
-				"├── happy/\n" +
 				"├── secretFolder/\n" +
 				"│   └── found you\n" +
 				"└── mySecret\n",
@@ -137,7 +122,6 @@ func TestSimpleTree(t *testing.T) {
 				},
 			},
 			expectedOutput: "test/repo/\n" +
-				"test/repo/happy/\n" +
 				"test/repo/secretFolder/\n" +
 				"test/repo/secretFolder/found you\n" +
 				"test/repo/mySecret\n",
@@ -245,7 +229,7 @@ func TestTreeColoring(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			w := &bytes.Buffer{}
+			w := new(bytes.Buffer)
 			tc.cmd.printTree(tree, w)
 			assert.Equal(t, w.String(), tc.expectedOutput)
 		})

--- a/internals/secrethub/tree_test.go
+++ b/internals/secrethub/tree_test.go
@@ -1,0 +1,253 @@
+package secrethub
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/secrethub/secrethub-cli/internals/cli/ui"
+	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/internals/api/uuid"
+	"github.com/secrethub/secrethub-go/internals/assert"
+	"github.com/secrethub/secrethub-go/pkg/secrethub"
+)
+
+func TestSimpleTree(t *testing.T) {
+	uuid0, _ := uuid.FromString("0")
+	uuid1, _ := uuid.FromString("1")
+	uuid2, _ := uuid.FromString("2")
+	tree := &api.Tree{
+		RootDir: &api.Dir{
+			Name:  "test/repo",
+			DirID: uuid0,
+			SubDirs: []*api.Dir{
+				{
+					Name:     "happy",
+					DirID:    uuid1,
+					ParentID: &uuid0,
+				},
+				{
+					Name:     "secretFolder",
+					DirID:    uuid2,
+					ParentID: &uuid0,
+					Secrets: []*api.Secret{
+						{Name: "found you"},
+					},
+				},
+			},
+			Secrets: []*api.Secret{
+				{Name: "mySecret"},
+			},
+		},
+		Dirs: map[uuid.UUID]*api.Dir{
+			uuid.New(): {
+				DirID:    uuid0,
+				ParentID: &uuid0,
+			},
+			uuid.New(): {
+				Name:     "happy",
+				DirID:    uuid1,
+				ParentID: &uuid0,
+			},
+			uuid.New(): {
+				Name:     "secretFolder",
+				DirID:    uuid2,
+				ParentID: &uuid0,
+				Secrets: []*api.Secret{
+					{Name: "found you"},
+				},
+			},
+		},
+		Secrets: map[uuid.UUID]*api.Secret{
+			uuid.New(): {Name: "found you"},
+			uuid.New(): {Name: "mySecret"},
+		},
+	}
+	cases := map[string]struct {
+		cmd            *TreeCommand
+		expectedOutput string
+	}{
+		"simple tree": {
+			cmd: &TreeCommand{
+				io: ui.NewUserIO(),
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"├── happy/\n" +
+				"├── secretFolder/\n" +
+				"│   └── found you\n" +
+				"└── mySecret\n\n" +
+				"2 directories, 2 secrets\n",
+		},
+		"full path": {
+			cmd: &TreeCommand{
+				path:      "test/repo",
+				io:        ui.NewUserIO(),
+				fullPaths: true,
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"├── test/repo/happy/\n" +
+				"├── test/repo/secretFolder/\n" +
+				"│   └── test/repo/secretFolder/found you\n" +
+				"└── test/repo/mySecret\n\n" +
+				"2 directories, 2 secrets\n",
+		},
+		"no indent": {
+			cmd: &TreeCommand{
+				io:            ui.NewUserIO(),
+				noIndentation: true,
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"happy/\n" +
+				"secretFolder/\n" +
+				"found you\n" +
+				"mySecret\n\n" +
+				"2 directories, 2 secrets\n",
+		},
+		"no report": {
+			cmd: &TreeCommand{
+				io:       ui.NewUserIO(),
+				noReport: true,
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"├── happy/\n" +
+				"├── secretFolder/\n" +
+				"│   └── found you\n" +
+				"└── mySecret\n",
+		},
+		"all flags": {
+			cmd: &TreeCommand{
+				path:          "test/repo",
+				io:            ui.NewUserIO(),
+				fullPaths:     true,
+				noIndentation: true,
+				noReport:      true,
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"test/repo/happy/\n" +
+				"test/repo/secretFolder/\n" +
+				"test/repo/secretFolder/found you\n" +
+				"test/repo/mySecret\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			tc.cmd.printTree(tree, w)
+			assert.Equal(t, w.String(), tc.expectedOutput)
+		})
+	}
+}
+
+func TestTreeColoring(t *testing.T) {
+	uuid0, _ := uuid.FromString("0")
+	uuid1, _ := uuid.FromString("1")
+	uuid2, _ := uuid.FromString("2")
+	tree := &api.Tree{
+		RootDir: &api.Dir{
+			Name:   "test/repo",
+			Status: "flagged",
+			DirID:  uuid0,
+			SubDirs: []*api.Dir{
+				{
+					Name:     "happy",
+					DirID:    uuid1,
+					ParentID: &uuid0,
+				},
+				{
+					Name:     "secretFolder",
+					DirID:    uuid2,
+					ParentID: &uuid0,
+					Status:   "flagged",
+					Secrets: []*api.Secret{
+						{
+							Name:   "found you",
+							Status: "flagged",
+						},
+					},
+				},
+			},
+			Secrets: []*api.Secret{
+				{Name: "mySecret"},
+			},
+		},
+		Dirs: map[uuid.UUID]*api.Dir{
+			uuid.New(): {
+				DirID:    uuid0,
+				ParentID: &uuid0,
+			},
+			uuid.New(): {
+				Name:     "happy",
+				DirID:    uuid1,
+				ParentID: &uuid0,
+			},
+			uuid.New(): {
+				Name:     "secretFolder",
+				DirID:    uuid2,
+				ParentID: &uuid0,
+				Secrets: []*api.Secret{
+					{Name: "found you"},
+				},
+			},
+		},
+		Secrets: map[uuid.UUID]*api.Secret{
+			uuid.New(): {Name: "found you"},
+			uuid.New(): {Name: "mySecret"},
+		},
+	}
+	cases := map[string]struct {
+		cmd            *TreeCommand
+		expectedOutput string
+	}{
+		"simple tree": {
+			cmd: &TreeCommand{
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"├── happy/\n" +
+				"├── secretFolder/\n" +
+				"│   └── found you\n" +
+				"└── mySecret\n\n" +
+				"2 directories, 2 secrets\n",
+		},
+		"full path": {
+			cmd: &TreeCommand{
+				path:      "test/repo",
+				fullPaths: true,
+				newClient: func() (secrethub.ClientInterface, error) {
+					return &secrethub.Client{}, nil
+				},
+			},
+			expectedOutput: "test/repo/\n" +
+				"├── test/repo/happy/\n" +
+				"├── test/repo/secretFolder/\n" +
+				"│   └── test/repo/secretFolder/found you\n" +
+				"└── test/repo/mySecret\n\n" +
+				"2 directories, 2 secrets\n",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			tc.cmd.printTree(tree, w)
+			assert.Equal(t, w.String(), tc.expectedOutput)
+		})
+	}
+}


### PR DESCRIPTION
This PR contains the implementation of 3 flags for the `tree` command in the CLI:
 - `-f` for full path of the directories and secrets
 - `-i` for no indentation
 - `--no-report` for skipping the report at the end