### PR TITLE
Include test case for clipboard for the 'secrethub generate' command

### DIFF
--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -21,6 +21,8 @@ func newIntValue(v int) intValue {
 
 func TestGenerateSecretCommand_run(t *testing.T) {
 	testErr := errio.Namespace("test").Code("test").Error("test error")
+	testData := []byte("random generated secret")
+	testPath := "namespace/repo/secret"
 
 	cases := map[string]struct {
 		cmd               GenerateSecretCommand
@@ -34,26 +36,26 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		"success": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
-				firstArg: "namespace/repo/secret",
+				firstArg: testPath,
 			},
 			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
 				return &api.SecretVersion{Version: 1}, nil
 			},
 			path: "namespace/repo/secret",
-			data: []byte("random generated secret"),
+			data: testData,
 			err:  nil,
 			out:  "A randomly generated secret has been written to namespace/repo/secret:1.\n",
 		},
 		"copy to clipboard": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
-				firstArg:        "namespace/repo/secret",
+				firstArg:        testPath,
 				copyToClipboard: true,
 				clipper:         fakeclip.New(),
 			},
@@ -61,35 +63,35 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 				return &api.SecretVersion{Version: 1}, nil
 			},
 			path: "namespace/repo/secret",
-			data: []byte("random generated secret"),
+			data: testData,
 			out: "A randomly generated secret has been written to namespace/repo/secret:1.\n" +
 				"The generated value has been copied to the clipboard. It will be cleared after Less than a second.\n",
 		},
 		"length flag": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
-				firstArg:   "namespace/repo/secret",
+				firstArg:   testPath,
 				lengthFlag: newIntValue(24),
 			},
 			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
 				return &api.SecretVersion{Version: 1}, nil
 			},
 			path: "namespace/repo/secret",
-			data: []byte("random generated secret"),
+			data: testData,
 			err:  nil,
 			out:  "A randomly generated secret has been written to namespace/repo/secret:1.\n",
 		},
 		"length flag and arg": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
 				firstArg:   "rand",
-				secondArg:  "namespace/repo/secret",
+				secondArg:  testPath,
 				lengthFlag: newIntValue(24),
 				lengthArg:  newIntValue(24),
 			},
@@ -98,25 +100,25 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		"backwards compatibility rand": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
 				firstArg:  "rand",
-				secondArg: "namespace/repo/secret",
+				secondArg: testPath,
 				lengthArg: newIntValue(23),
 			},
 			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
 				return &api.SecretVersion{Version: 1}, nil
 			},
 			path: "namespace/repo/secret",
-			data: []byte("random generated secret"),
+			data: testData,
 			err:  nil,
 			out:  "A randomly generated secret has been written to namespace/repo/secret:1.\n",
 		},
 		"length arg 0": {
 			cmd: GenerateSecretCommand{
 				firstArg:  "rand",
-				secondArg: "namespace/repo/secret",
+				secondArg: testPath,
 				lengthArg: newIntValue(0),
 			},
 			err: ErrInvalidRandLength,
@@ -125,7 +127,7 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		"length arg negative": {
 			cmd: GenerateSecretCommand{
 				firstArg:  "rand",
-				secondArg: "namespace/repo/secret",
+				secondArg: testPath,
 				lengthArg: newIntValue(-1),
 			},
 			err: ErrInvalidRandLength,
@@ -134,7 +136,7 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		// The length arg is only for backwards compatibility of the `generate rand` command.
 		"length arg without rand": {
 			cmd: GenerateSecretCommand{
-				firstArg:  "namespace/repo/secret",
+				firstArg:  testPath,
 				lengthArg: newIntValue(24),
 			},
 			err: errors.New("unexpected 24"),
@@ -142,7 +144,7 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		// The second arg should only be used to supply the path when the first arg is `rand` (backwards compatibility).
 		"second arg without rand": {
 			cmd: GenerateSecretCommand{
-				firstArg:  "namespace/repo/secret",
+				firstArg:  testPath,
 				secondArg: "namespace/repo/secret2",
 			},
 			err: errors.New("unexpected namespace/repo/secret2"),
@@ -153,17 +155,17 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 					Ret: nil,
 					Err: testErr,
 				},
-				firstArg: "namespace/repo/secret",
+				firstArg: testPath,
 			},
 			err: testErr,
 		},
 		"client creation error": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
-				firstArg: "namespace/repo/secret",
+				firstArg: testPath,
 			},
 			clientCreationErr: testErr,
 			err:               testErr,
@@ -171,16 +173,16 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 		"client error": {
 			cmd: GenerateSecretCommand{
 				generator: randchargeneratorfakes.FakeRandomGenerator{
-					Ret: []byte("random generated secret"),
+					Ret: testData,
 					Err: nil,
 				},
-				firstArg: "namespace/repo/secret",
+				firstArg: testPath,
 			},
 			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
 				return nil, testErr
 			},
 			path: "namespace/repo/secret",
-			data: []byte("random generated secret"),
+			data: testData,
 			err:  testErr,
 		},
 	}
@@ -191,6 +193,9 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 			var argData []byte
 
 			// Setup
+			testIO := fakeui.NewIO(t)
+			tc.cmd.io = testIO
+
 			tc.cmd.newClient = func() (secrethub.ClientInterface, error) {
 				return fakeclient.Client{
 					SecretService: &fakeclient.SecretService{
@@ -203,9 +208,6 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 				}, tc.clientCreationErr
 			}
 
-			io := fakeui.NewIO(t)
-			tc.cmd.io = io
-
 			// Act
 			err := tc.cmd.run()
 
@@ -213,7 +215,7 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 			assert.Equal(t, err, tc.err)
 			assert.Equal(t, argPath, tc.path)
 			assert.Equal(t, argData, tc.data)
-			assert.Equal(t, io.Out.String(), tc.out)
+			assert.Equal(t, testIO.Out.String(), tc.out)
 		})
 	}
 }

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -2,9 +2,9 @@ package secrethub
 
 import (
 	"errors"
-	"github.com/secrethub/secrethub-cli/internals/cli/clip/fakeclip"
 	"testing"
 
+	"github.com/secrethub/secrethub-cli/internals/cli/clip/fakeclip"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui/fakeui"
 
 	"github.com/secrethub/secrethub-go/internals/api"

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -2,6 +2,7 @@ package secrethub
 
 import (
 	"errors"
+	"github.com/secrethub/secrethub-cli/internals/cli/clip/fakeclip"
 	"testing"
 
 	"github.com/secrethub/secrethub-cli/internals/cli/ui/fakeui"
@@ -45,6 +46,24 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 			data: []byte("random generated secret"),
 			err:  nil,
 			out:  "A randomly generated secret has been written to namespace/repo/secret:1.\n",
+		},
+		"copy to clipboard": {
+			cmd: GenerateSecretCommand{
+				generator: randchargeneratorfakes.FakeRandomGenerator{
+					Ret: []byte("random generated secret"),
+					Err: nil,
+				},
+				firstArg:        "namespace/repo/secret",
+				copyToClipboard: true,
+				clipper:         fakeclip.New(),
+			},
+			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
+				return &api.SecretVersion{Version: 1}, nil
+			},
+			path: "namespace/repo/secret",
+			data: []byte("random generated secret"),
+			out: "A randomly generated secret has been written to namespace/repo/secret:1.\n" +
+				"The generated value has been copied to the clipboard. It will be cleared after Less than a second.\n",
 		},
 		"length flag": {
 			cmd: GenerateSecretCommand{

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -25,14 +25,14 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 	testPath := "namespace/repo/secret"
 
 	cases := map[string]struct {
-		cmd               GenerateSecretCommand
-		writeFunc         func(path string, data []byte) (*api.SecretVersion, error)
-		clientCreationErr error
-		path              api.SecretPath
-		data              []byte
-		expectedClip      []byte
-		err               error
-		out               string
+		cmd          GenerateSecretCommand
+		writeFunc    func(path string, data []byte) (*api.SecretVersion, error)
+		newClientErr error
+		path         api.SecretPath
+		data         []byte
+		expectedClip []byte
+		err          error
+		out          string
 	}{
 		"success": {
 			cmd: GenerateSecretCommand{
@@ -179,8 +179,8 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 				firstArg: testPath,
 				clipper:  fakeclip.New(),
 			},
-			clientCreationErr: testErr,
-			err:               testErr,
+			newClientErr: testErr,
+			err:          testErr,
 		},
 		"client error": {
 			cmd: GenerateSecretCommand{
@@ -218,7 +218,7 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 							return tc.writeFunc(path, data)
 						},
 					},
-				}, tc.clientCreationErr
+				}, tc.newClientErr
 			}
 
 			// Act

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -64,8 +64,8 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 			writeFunc: func(path string, data []byte) (*api.SecretVersion, error) {
 				return &api.SecretVersion{Version: 1}, nil
 			},
-			path: "namespace/repo/secret",
-			data: testData,
+			path:         "namespace/repo/secret",
+			data:         testData,
 			expectedClip: testData,
 			out: "A randomly generated secret has been written to namespace/repo/secret:1.\n" +
 				"The generated value has been copied to the clipboard. It will be cleared after Less than a second.\n",

--- a/internals/secrethub/generate_test.go
+++ b/internals/secrethub/generate_test.go
@@ -223,9 +223,10 @@ func TestGenerateSecretCommand_run(t *testing.T) {
 
 			// Act
 			err := tc.cmd.run()
-			resClip, _ := tc.cmd.clipper.ReadAll()
+			resClip, clipErr := tc.cmd.clipper.ReadAll()
 
 			// Assert
+			assert.OK(t, clipErr)
 			assert.Equal(t, err, tc.err)
 			assert.Equal(t, argPath, tc.path)
 			assert.Equal(t, argData, tc.data)


### PR DESCRIPTION
This PR contains one extra test in which the clipboard is selected as the output