### PR TITLE
Hotfix: fix test failing 50% of times

### DIFF
--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -24,13 +24,12 @@ import (
 )
 
 type errNameCollision struct {
-	name       string
-	firstPath  string
-	secondPath string
+	name  string
+	paths [2]string
 }
 
 func (e errNameCollision) Error() string {
-	return fmt.Sprintf("secrets at path %s and %s map to the same environment variable: %s. Rename one of the secrets or source them in a different way", e.firstPath, e.secondPath, e.name)
+	return fmt.Sprintf("secrets at path %s and %s map to the same environment variable: %s. Rename one of the secrets or source them in a different way", e.paths[0], e.paths[1], e.name)
 }
 
 type environment struct {
@@ -225,9 +224,11 @@ func (s *secretsDirEnv) env() (map[string]value, error) {
 		envVarName := s.envVarName(path)
 		if prevPath, found := paths[envVarName]; found {
 			return nil, errNameCollision{
-				name:       envVarName,
-				firstPath:  prevPath,
-				secondPath: path,
+				name: envVarName,
+				paths: [2]string{
+					prevPath,
+					path,
+				},
 			}
 		}
 		paths[envVarName] = path


### PR DESCRIPTION
Success on the executing order of a range over a map. As the order for looping of maps is undetermined, the test result was also undetermined.

By first performing a sort in the test, the result is no longer dependent, the assertion no succeeds indepedently of the executing within this loop.