### PR TITLE
Rename credential.Reader to PassphraseReader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/secrethub/demo-app v0.1.0
-	github.com/secrethub/secrethub-go v0.30.0
+	github.com/secrethub/secrethub-go v0.30.1-0.20201019102115-41563feace06
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,10 @@ github.com/secrethub/secrethub-go v0.29.1-0.20200707154958-5e5602145597 h1:uC9OD
 github.com/secrethub/secrethub-go v0.29.1-0.20200707154958-5e5602145597/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
 github.com/secrethub/secrethub-go v0.30.0 h1:Nh1twPDwPbYQj/cYc1NG+j7sv76LZiXLPovyV83tZj0=
 github.com/secrethub/secrethub-go v0.30.0/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
+github.com/secrethub/secrethub-go v0.30.1-0.20201019093244-fe328a799a81 h1:OM/fDm+rREF4HvPbMK9yCMeS2jlP2BpnSX4Shd2hDUE=
+github.com/secrethub/secrethub-go v0.30.1-0.20201019093244-fe328a799a81/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
+github.com/secrethub/secrethub-go v0.30.1-0.20201019102115-41563feace06 h1:GssQpC4pFkRU/yZDl15M7iWpHJr+F6z05jPmcOZncj0=
+github.com/secrethub/secrethub-go v0.30.1-0.20201019102115-41563feace06/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/internals/secrethub/account_init.go
+++ b/internals/secrethub/account_init.go
@@ -176,7 +176,7 @@ func (cmd *AccountInitCommand) Run() error {
 
 		exportKey := credential.Key
 		if passphrase != "" {
-			exportKey = exportKey.Passphrase(credentials.FromString(passphrase))
+			exportKey = exportKey.Passphrase(credentials.PassphraseFromString(passphrase))
 		}
 
 		exportedCredential, err := exportKey.Export()

--- a/internals/secrethub/config_update_passphrase.go
+++ b/internals/secrethub/config_update_passphrase.go
@@ -63,7 +63,7 @@ func (cmd *ConfigUpdatePassphraseCommand) Run() error {
 		return err
 	}
 	if passphrase != "" {
-		credential = credential.Passphrase(credentials.FromString(passphrase))
+		credential = credential.Passphrase(credentials.PassphraseFromString(passphrase))
 	}
 	exportedCredential, err := credential.Export()
 	if err != nil {

--- a/internals/secrethub/init.go
+++ b/internals/secrethub/init.go
@@ -181,7 +181,7 @@ func (cmd *InitCommand) Run() error {
 
 		exportKey := credential.Key
 		if passphrase != "" {
-			exportKey = exportKey.Passphrase(credentials.FromString(passphrase))
+			exportKey = exportKey.Passphrase(credentials.PassphraseFromString(passphrase))
 		}
 
 		exportedKey, err := exportKey.Export()

--- a/internals/secrethub/keyring.go
+++ b/internals/secrethub/keyring.go
@@ -67,7 +67,7 @@ func (pr *passphraseReader) Read() ([]byte, error) {
 }
 
 // NewPassphraseReader constructs a new PassphraseReader using values in the CLI.
-func NewPassphraseReader(io ui.IO, credentialPassphrase string, credentialPassphraseTTL time.Duration) credentials.Reader {
+func NewPassphraseReader(io ui.IO, credentialPassphrase string, credentialPassphraseTTL time.Duration) credentials.PassphraseReader {
 	ttl := credentialPassphraseTTL
 	cleaner := NewKeyringCleaner()
 	keyring := NewKeyring()

--- a/internals/secrethub/signup.go
+++ b/internals/secrethub/signup.go
@@ -152,7 +152,7 @@ func (cmd *SignUpCommand) Run() error {
 
 	exportKey := credential.Key
 	if passphrase != "" {
-		exportKey = exportKey.Passphrase(credentials.FromString(passphrase))
+		exportKey = exportKey.Passphrase(credentials.PassphraseFromString(passphrase))
 	}
 
 	encodedCredential, err := credential.Export()


### PR DESCRIPTION
This PR implements the CLI changes required by https://github.com/secrethub/secrethub-go/pull/222. Namely renaming `credential.Reader` to `credential.PassphraseReader`.