### PR TITLE
Move update-passphrase command to "credential" management command

### DIFF
--- a/internals/secrethub/config.go
+++ b/internals/secrethub/config.go
@@ -22,6 +22,6 @@ func NewConfigCommand(io ui.IO, store CredentialConfig) *ConfigCommand {
 // Register registers the command and its sub-commands on the provided Registerer.
 func (cmd *ConfigCommand) Register(r command.Registerer) {
 	clause := r.Command("config", "Manage your local configuration.").Hidden()
-	NewConfigUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
+	NewCredentialUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
 	NewConfigUpgradeCommand().Register(clause)
 }

--- a/internals/secrethub/config.go
+++ b/internals/secrethub/config.go
@@ -21,7 +21,7 @@ func NewConfigCommand(io ui.IO, store CredentialConfig) *ConfigCommand {
 
 // Register registers the command and its sub-commands on the provided Registerer.
 func (cmd *ConfigCommand) Register(r command.Registerer) {
-	clause := r.Command("config", "Manage your local configuration.")
+	clause := r.Command("config", "Manage your local configuration.").Hidden()
 	NewConfigUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
 	NewConfigUpgradeCommand().Register(clause)
 }

--- a/internals/secrethub/credential.go
+++ b/internals/secrethub/credential.go
@@ -27,4 +27,5 @@ func (cmd *CredentialCommand) Register(r command.Registerer) {
 	NewCredentialListCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
 	NewCredentialBackupCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
 	NewCredentialDisableCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
+	NewConfigUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
 }

--- a/internals/secrethub/credential.go
+++ b/internals/secrethub/credential.go
@@ -27,5 +27,5 @@ func (cmd *CredentialCommand) Register(r command.Registerer) {
 	NewCredentialListCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
 	NewCredentialBackupCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
 	NewCredentialDisableCommand(cmd.io, cmd.clientFactory.NewClient).Register(clause)
-	NewConfigUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
+	NewCredentialUpdatePassphraseCommand(cmd.io, cmd.credentialStore).Register(clause)
 }

--- a/internals/secrethub/credential_update_passphrase.go
+++ b/internals/secrethub/credential_update_passphrase.go
@@ -9,28 +9,28 @@ import (
 	"github.com/secrethub/secrethub-cli/internals/secrethub/command"
 )
 
-type ConfigUpdatePassphraseCommand struct {
+type CredentialUpdatePassphraseCommand struct {
 	io              ui.IO
 	credentialStore CredentialConfig
 }
 
-// NewConfigUpdatePassphraseCommand creates a new ConfigUpdatePassphraseCommand.
-func NewConfigUpdatePassphraseCommand(io ui.IO, credentialStore CredentialConfig) *ConfigUpdatePassphraseCommand {
-	return &ConfigUpdatePassphraseCommand{
+// NewCredentialUpdatePassphraseCommand creates a new CredentialUpdatePassphraseCommand.
+func NewCredentialUpdatePassphraseCommand(io ui.IO, credentialStore CredentialConfig) *CredentialUpdatePassphraseCommand {
+	return &CredentialUpdatePassphraseCommand{
 		io:              io,
 		credentialStore: credentialStore,
 	}
 }
 
 // Register registers the command, arguments and flags on the provided Registerer.
-func (cmd *ConfigUpdatePassphraseCommand) Register(r command.Registerer) {
+func (cmd *CredentialUpdatePassphraseCommand) Register(r command.Registerer) {
 	clause := r.Command("update-passphrase", "Update the passphrase of your local key credential file.")
 
 	command.BindAction(clause, cmd.Run)
 }
 
 // Run upgrades the configuration in the profile directory to the new version.
-func (cmd *ConfigUpdatePassphraseCommand) Run() error {
+func (cmd *CredentialUpdatePassphraseCommand) Run() error {
 	if !cmd.credentialStore.ConfigDir().Credential().Exists() {
 		fmt.Println("No credentials. Nothing to do.")
 		return nil


### PR DESCRIPTION
Now that we have a `credential` management command, I believe it's more intuitive to group `update-passphrase` in there as well. What do you think?

This deprecates `secrethub config update-passphrase` command, in favor of `secrethub credential update-passphrase`.