### PR TITLE
Improve credential errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/secrethub/demo-app v0.1.0
-	github.com/secrethub/secrethub-go v0.31.0
+	github.com/secrethub/secrethub-go v0.30.1-0.20201215150659-e5f45b9d8a0d
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/sys v0.0.0-20200501052902-10377860bb8e

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/secrethub/secrethub-go v0.29.1-0.20200728110331-9d7b31301226/go.mod h
 github.com/secrethub/secrethub-go v0.29.1-0.20200728110331-9d7b31301226/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
 github.com/secrethub/secrethub-go v0.30.0 h1:Nh1twPDwPbYQj/cYc1NG+j7sv76LZiXLPovyV83tZj0=
 github.com/secrethub/secrethub-go v0.30.0/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
+github.com/secrethub/secrethub-go v0.30.1-0.20201215150659-e5f45b9d8a0d h1:5HtPCmZWsK3hLHyT825lhp6361uu3gRFJFN7MLr36ec=
+github.com/secrethub/secrethub-go v0.30.1-0.20201215150659-e5f45b9d8a0d/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
 github.com/secrethub/secrethub-go v0.31.0 h1:0KoG0KHBOa5knkvf3K0f6sKuPSQ5VGPXLD4ttC9Eul8=
 github.com/secrethub/secrethub-go v0.31.0/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/internals/secrethub/client_factory.go
+++ b/internals/secrethub/client_factory.go
@@ -40,6 +40,7 @@ type clientFactory struct {
 }
 
 // Register the flags for configuration on a cli application.
+// The environment variables of these flags are also checked on the client, but checking them here allows us to fail fast.
 func (f *clientFactory) Register(r FlagRegisterer) {
 	r.Flag("api-remote", "The SecretHub API address, don't set this unless you know what you're doing.").Hidden().URLVar(&f.ServerURL)
 	r.Flag("identity-provider", "Enable native authentication with a trusted identity provider. Options are `aws` (IAM + KMS), `gcp` (IAM + KMS) and `key`. When you run the CLI on one of the platforms, you can leverage their respective identity providers to do native keyless authentication. Defaults to key, which uses the default credential sourced from a file, command-line flag, or environment variable. ").Default("key").StringVar(&f.identityProvider)

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -51,6 +51,7 @@ func (store *credentialConfig) IsPassphraseSet() bool {
 }
 
 // Register registers the flags for configuring the store on the provided Registerer.
+// The environment variables of these flags are also checked on the client, but checking them here allows us to fail fast.
 func (store *credentialConfig) Register(r FlagRegisterer) {
 	r.Flag("config-dir", "The absolute path to a custom configuration directory. Defaults to $HOME/.secrethub").Default("").PlaceHolder("CONFIG-DIR").SetValue(&store.configDir)
 	store.credentialFlag = r.Flag("credential", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.")

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -1,8 +1,9 @@
 package secrethub
 
 import (
-	"github.com/secrethub/secrethub-cli/internals/cli"
 	"time"
+
+	"github.com/secrethub/secrethub-cli/internals/cli"
 
 	"github.com/secrethub/secrethub-go/pkg/secrethub/configdir"
 	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
@@ -78,9 +79,8 @@ func (store *credentialConfig) getCredentialReader() credentials.Reader {
 	}
 	if store.credentialFlag.HasEnvarValue() {
 		return credentials.FromEnv("SECRETHUB_CREDENTIAL")
-	} else {
-		return credentials.FromString(store.AccountCredential)
 	}
+	return credentials.FromString(store.AccountCredential)
 }
 
 // PassphraseReader returns a PassphraseReader configured by the flags.

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -1,6 +1,7 @@
 package secrethub
 
 import (
+	"github.com/secrethub/secrethub-cli/internals/cli"
 	"time"
 
 	"github.com/secrethub/secrethub-go/pkg/secrethub/configdir"
@@ -35,6 +36,7 @@ func NewCredentialConfig(io ui.IO) CredentialConfig {
 type credentialConfig struct {
 	configDir                    ConfigDir
 	AccountCredential            string
+	credentialFlag               *cli.Flag
 	credentialPassphrase         string
 	CredentialPassphraseCacheTTL time.Duration
 	io                           ui.IO
@@ -51,7 +53,8 @@ func (store *credentialConfig) IsPassphraseSet() bool {
 // Register registers the flags for configuring the store on the provided Registerer.
 func (store *credentialConfig) Register(r FlagRegisterer) {
 	r.Flag("config-dir", "The absolute path to a custom configuration directory. Defaults to $HOME/.secrethub").Default("").PlaceHolder("CONFIG-DIR").SetValue(&store.configDir)
-	r.Flag("credential", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.").StringVar(&store.AccountCredential)
+	store.credentialFlag = r.Flag("credential", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.")
+	store.credentialFlag.StringVar(&store.AccountCredential)
 	r.Flag("p", "").Short('p').Hidden().NoEnvar().StringVar(&store.credentialPassphrase) // Shorthand -p is deprecated. Use --credential-passphrase instead.
 	r.Flag("credential-passphrase", "The passphrase to unlock your credential file. When set, it will not prompt for the passphrase, nor cache it in the OS keyring. Please only use this if you know what you're doing and ensure your passphrase doesn't end up in bash history.").StringVar(&store.credentialPassphrase)
 	r.Flag("credential-passphrase-cache-ttl", "Cache the credential passphrase in the OS keyring for this duration. The cache is automatically cleared after the timer runs out. Each time the passphrase is read from the cache the timer is reset. Passphrase caching is turned on by default for 5 minutes. Turn it off by setting the duration to 0.").Default("5m").DurationVar(&store.CredentialPassphraseCacheTTL)
@@ -69,10 +72,14 @@ func (store *credentialConfig) Import() (credentials.Key, error) {
 }
 
 func (store *credentialConfig) getCredentialReader() credentials.Reader {
-	if store.AccountCredential != "" {
+	if store.AccountCredential == "" {
+		return store.configDir.Credential()
+	}
+	if store.credentialFlag.HasEnvarValue() {
+		return credentials.FromEnv("SECRETHUB_CREDENTIAL")
+	} else {
 		return credentials.FromString(store.AccountCredential)
 	}
-	return store.configDir.Credential()
 }
 
 // PassphraseReader returns a PassphraseReader configured by the flags.


### PR DESCRIPTION
This PR, in combination with https://github.com/secrethub/secrethub-go/pull/223 ensures that all credential related errors are wrapped with a message that includes the source of the credential (except if the credential is passed via a cli flag).