### PR TITLE
account inspect for service accounts

### DIFF
--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -107,7 +107,6 @@ func newOutputUser(user *api.User, timeFormatter TimeFormatter) *outputUser {
 // outputService is a user friendly JSON representation of a service account.
 type outputService struct {
 	Description string
-	CreatedAt   string `json:",omitempty"`
 	outputAccount
 }
 

--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -40,38 +40,84 @@ func (cmd *AccountInspectCommand) Run() error {
 		return err
 	}
 
-	user, err := client.Users().Me()
+	account, err := client.Accounts().Me()
 	if err != nil {
 		return err
 	}
-
-	output, err := cli.PrettyJSON(newOutputUser(user, cmd.timeFormatter))
-	if err != nil {
-		return err
+	var output string
+	if account.AccountType == "user" {
+		user, err := client.Users().Me()
+		if err != nil {
+			return err
+		}
+		output, err = cli.PrettyJSON(newOutputUser(user, cmd.timeFormatter))
+		if err != nil {
+			return err
+		}
+	} else if account.AccountType == "service" {
+		service, err := client.Services().Get(account.Name.String())
+		if err != nil {
+			return err
+		}
+		output, err = cli.PrettyJSON(newOutputService(service, account, cmd.timeFormatter))
+		if err != nil {
+			return err
+		}
 	}
-
 	fmt.Fprintln(cmd.io.Output(), output)
 
 	return nil
 }
 
+// outputAccount contains the fields common in both outputUser and outputService
+type outputAccount struct {
+	AccountType      string
+	AccountName      string
+	PublicAccountKey []byte `json:",omitempty"`
+}
+
 // outputUser is a user friendly JSON representation of a user account.
 type outputUser struct {
-	Username         string
-	FullName         string
-	Email            string `json:",omitempty"`
-	EmailVerified    bool   `json:",omitempty"`
-	CreatedAt        string `json:",omitempty"`
-	PublicAccountKey []byte `json:",omitempty"`
+	Username      string
+	FullName      string
+	Email         string `json:",omitempty"`
+	EmailVerified bool   `json:",omitempty"`
+	CreatedAt     string `json:",omitempty"`
+	outputAccount
 }
 
 func newOutputUser(user *api.User, timeFormatter TimeFormatter) *outputUser {
 	return &outputUser{
-		Username:         user.Username,
-		FullName:         user.FullName,
-		Email:            user.Email,
-		EmailVerified:    user.EmailVerified,
-		CreatedAt:        timeFormatter.Format(user.CreatedAt.Local()),
-		PublicAccountKey: user.PublicKey,
+		Username:      user.Username,
+		FullName:      user.FullName,
+		Email:         user.Email,
+		EmailVerified: user.EmailVerified,
+		CreatedAt:     timeFormatter.Format(user.CreatedAt.Local()),
+		outputAccount: outputAccount{
+			AccountType:      "user",
+			AccountName:      user.Username,
+			PublicAccountKey: user.PublicKey,
+		},
+	}
+}
+
+// outputService is a user friendly JSON representation of a service account.
+type outputService struct {
+	Description string
+	CreatedBy   string
+	CreatedAt   string `json:",omitempty"`
+	outputAccount
+}
+
+func newOutputService(service *api.Service, account *api.Account, timeFormatter TimeFormatter) *outputService {
+	return &outputService{
+		Description: service.Description,
+		CreatedBy:   service.CreatedBy.String(),
+		CreatedAt:   timeFormatter.Format(service.CreatedAt.Local()),
+		outputAccount: outputAccount{
+			AccountType:      "service",
+			AccountName:      service.ServiceID,
+			PublicAccountKey: account.PublicKey,
+		},
 	}
 }

--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -107,7 +107,6 @@ func newOutputUser(user *api.User, timeFormatter TimeFormatter) *outputUser {
 // outputService is a user friendly JSON representation of a service account.
 type outputService struct {
 	Description string
-	CreatedBy   string
 	CreatedAt   string `json:",omitempty"`
 	outputAccount
 }
@@ -115,7 +114,6 @@ type outputService struct {
 func newOutputService(service *api.Service, account *api.Account, timeFormatter TimeFormatter) *outputService {
 	return &outputService{
 		Description: service.Description,
-		CreatedBy:   service.CreatedBy.String(),
 		CreatedAt:   timeFormatter.Format(service.CreatedAt.Local()),
 		outputAccount: outputAccount{
 			AccountType:      accountTypeService,

--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -76,6 +76,7 @@ func (cmd *AccountInspectCommand) Run() error {
 type outputAccount struct {
 	AccountType      string
 	AccountName      string
+	CreatedAt        string `json:",omitempty"`
 	PublicAccountKey []byte `json:",omitempty"`
 }
 
@@ -85,7 +86,6 @@ type outputUser struct {
 	FullName      string
 	Email         string `json:",omitempty"`
 	EmailVerified bool   `json:",omitempty"`
-	CreatedAt     string `json:",omitempty"`
 	outputAccount
 }
 
@@ -95,10 +95,10 @@ func newOutputUser(user *api.User, timeFormatter TimeFormatter) *outputUser {
 		FullName:      user.FullName,
 		Email:         user.Email,
 		EmailVerified: user.EmailVerified,
-		CreatedAt:     timeFormatter.Format(user.CreatedAt.Local()),
 		outputAccount: outputAccount{
 			AccountType:      accountTypeUser,
 			AccountName:      user.Username,
+			CreatedAt:        timeFormatter.Format(user.CreatedAt.Local()),
 			PublicAccountKey: user.PublicKey,
 		},
 	}
@@ -114,10 +114,10 @@ type outputService struct {
 func newOutputService(service *api.Service, account *api.Account, timeFormatter TimeFormatter) *outputService {
 	return &outputService{
 		Description: service.Description,
-		CreatedAt:   timeFormatter.Format(service.CreatedAt.Local()),
 		outputAccount: outputAccount{
 			AccountType:      accountTypeService,
 			AccountName:      service.ServiceID,
+			CreatedAt:        timeFormatter.Format(service.CreatedAt.Local()),
 			PublicAccountKey: account.PublicKey,
 		},
 	}

--- a/internals/secrethub/account_inspect.go
+++ b/internals/secrethub/account_inspect.go
@@ -10,6 +10,9 @@ import (
 	"github.com/secrethub/secrethub-go/internals/api"
 )
 
+const accountTypeUser string = "user"
+const accountTypeService string = "service"
+
 // AccountInspectCommand is a command to inspect account details.
 type AccountInspectCommand struct {
 	io            ui.IO
@@ -45,7 +48,7 @@ func (cmd *AccountInspectCommand) Run() error {
 		return err
 	}
 	var output string
-	if account.AccountType == "user" {
+	if account.AccountType == accountTypeUser {
 		user, err := client.Users().Me()
 		if err != nil {
 			return err
@@ -54,7 +57,7 @@ func (cmd *AccountInspectCommand) Run() error {
 		if err != nil {
 			return err
 		}
-	} else if account.AccountType == "service" {
+	} else if account.AccountType == accountTypeService {
 		service, err := client.Services().Get(account.Name.String())
 		if err != nil {
 			return err
@@ -94,7 +97,7 @@ func newOutputUser(user *api.User, timeFormatter TimeFormatter) *outputUser {
 		EmailVerified: user.EmailVerified,
 		CreatedAt:     timeFormatter.Format(user.CreatedAt.Local()),
 		outputAccount: outputAccount{
-			AccountType:      "user",
+			AccountType:      accountTypeUser,
 			AccountName:      user.Username,
 			PublicAccountKey: user.PublicKey,
 		},
@@ -115,7 +118,7 @@ func newOutputService(service *api.Service, account *api.Account, timeFormatter 
 		CreatedBy:   service.CreatedBy.String(),
 		CreatedAt:   timeFormatter.Format(service.CreatedAt.Local()),
 		outputAccount: outputAccount{
-			AccountType:      "service",
+			AccountType:      accountTypeService,
 			AccountName:      service.ServiceID,
 			PublicAccountKey: account.PublicKey,
 		},

--- a/internals/secrethub/account_inspect_test.go
+++ b/internals/secrethub/account_inspect_test.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"errors"
-	"github.com/secrethub/secrethub-go/internals/api/uuid"
 	"testing"
 	"time"
 
@@ -87,7 +86,6 @@ func TestAccountInspect(t *testing.T) {
 									return &api.Service{
 										ServiceID:   "s-abcdefghijkl",
 										Description: "Test description.",
-										CreatedBy:   uuid.UUID{},
 										CreatedAt:   time.Date(2020, 12, 12, 12, 12, 12, 0, time.UTC),
 									}, nil
 								}
@@ -103,7 +101,6 @@ func TestAccountInspect(t *testing.T) {
 			err: nil,
 			out: `{
     "Description": "Test description.",
-    "CreatedBy": "00000000-0000-0000-0000-000000000000",
     "CreatedAt": "2018-07-30T10:49:18Z",
     "AccountType": "service",
     "AccountName": "s-abcdefghijkl",

--- a/internals/secrethub/account_inspect_test.go
+++ b/internals/secrethub/account_inspect_test.go
@@ -60,9 +60,9 @@ func TestAccountInspect(t *testing.T) {
     "FullName": "Developer Uno",
     "Email": "dev1@keylocker.eu",
     "EmailVerified": true,
-    "CreatedAt": "2018-07-30T10:49:18Z",
     "AccountType": "user",
     "AccountName": "dev1",
+    "CreatedAt": "2018-07-30T10:49:18Z",
     "PublicAccountKey": "YWJjZGU="
 }
 `,
@@ -101,9 +101,9 @@ func TestAccountInspect(t *testing.T) {
 			err: nil,
 			out: `{
     "Description": "Test description.",
-    "CreatedAt": "2018-07-30T10:49:18Z",
     "AccountType": "service",
     "AccountName": "s-abcdefghijkl",
+    "CreatedAt": "2018-07-30T10:49:18Z",
     "PublicAccountKey": "YWJjZGU="
 }
 `,


### PR DESCRIPTION
This PR makes the `secrethub account inspect` command work for service accounts. The output of the command is extended to allow for easier parsing. The following fields are outputted:

for services:
- CreatedAt
- Description
- AccountType
- AccountName
- PublicAccountKey

for users:
- Username
- FullName
- Email
- EmailVerified
- CreatedAt
- AccountType
- AccountName
- PublicAccountKey