### PR TITLE
Allow configuring flags from env vars

### DIFF
--- a/internals/cli/env.go
+++ b/internals/cli/env.go
@@ -76,6 +76,12 @@ func (a *App) Command(name, help string) *CommandClause {
 	return clause
 }
 
+// PersistentFlags returns a flag set that allows configuring
+// global persistent flags (that work on all commands of the CLI).
+func (a *App) PersistentFlags() *FlagSet {
+	return &FlagSet{FlagSet: a.Cmd.Cmd.PersistentFlags(), cmd: a.Cmd}
+}
+
 // Version adds a flag for displaying the application version number.
 func (a *App) Version(version string) *App {
 	a.Cmd.Cmd.Version = version
@@ -290,10 +296,6 @@ func (c *CommandClause) Flag(name string) *Flag {
 
 func (c *CommandClause) Flags() *FlagSet {
 	return &FlagSet{FlagSet: c.Cmd.Flags(), cmd: c}
-}
-
-func (a *App) PersistentFlags() *FlagSet {
-	return &FlagSet{FlagSet: a.Cmd.Cmd.PersistentFlags(), cmd: a.Cmd}
 }
 
 // BindArguments binds a function to a command clause, so that

--- a/internals/cli/env.go
+++ b/internals/cli/env.go
@@ -37,7 +37,7 @@ type App struct {
 func NewApp(name, help string) *App {
 	app := &App{
 		Cmd: &CommandClause{
-			Cmd:   &cobra.Command{Use: name, Short: help, SilenceErrors: true, SilenceUsage: true},
+			Cmd: &cobra.Command{Use: name, Short: help, SilenceErrors: true, SilenceUsage: true},
 		},
 		name:             formatName(name, "", DefaultEnvSeparator, DefaultCommandDelimiters...),
 		delimiters:       DefaultCommandDelimiters,
@@ -183,10 +183,10 @@ func (a *App) CheckStrictEnv() error {
 
 // CommandClause represents a command clause in a command0-line application.
 type CommandClause struct {
-	Cmd  *cobra.Command
-	name string
-	App  *App
-	Args []Argument
+	Cmd   *cobra.Command
+	name  string
+	App   *App
+	Args  []Argument
 	flags []*Flag
 }
 
@@ -564,8 +564,9 @@ func shortDur(d *time.Duration) string {
 }
 
 type preRunAction func(*cobra.Command, []string) error
+
 func mergeFuncs(f1 preRunAction, f2 preRunAction) preRunAction {
-	if f1 == nil{
+	if f1 == nil {
 		return f2
 	}
 	return func(cmd *cobra.Command, args []string) error {

--- a/internals/cli/env.go
+++ b/internals/cli/env.go
@@ -177,6 +177,7 @@ type CommandClause struct {
 	name string
 	App  *App
 	Args []Argument
+	flags []*Flag
 }
 
 // Command adds a new subcommand to this command.
@@ -246,12 +247,14 @@ func (c *CommandClause) Flag(name string) *Flag {
 	envVar := formatName(name, prefix, c.App.separator, c.App.delimiters...)
 
 	c.App.registerEnvVar(envVar)
-	flag := c.Cmd.Flag(name)
-	return (&Flag{
-		Flag:   flag,
+	baseFlag := c.Cmd.Flag(name)
+	flag := (&Flag{
+		Flag:   baseFlag,
 		app:    c.App,
 		envVar: envVar,
 	}).Envar(envVar)
+	c.flags = append(c.flags, flag)
+	return flag
 }
 
 func (c *CommandClause) Flags() *FlagSet {

--- a/internals/demo/command.go
+++ b/internals/demo/command.go
@@ -1,7 +1,7 @@
 package demo
 
 import (
-	democli "github.com/secrethub/demo-app/cli"
+	// democli "github.com/secrethub/demo-app/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli/ui"
 )
@@ -26,5 +26,5 @@ func (cmd *Command) Register(r cli.Registerer) {
 	clause.Hidden()
 
 	NewInitCommand(cmd.io, cmd.newClient).Register(clause)
-	democli.NewServeCommand(cmd.io).Register(clause)
+	// democli.NewServeCommand(cmd.io).Register(clause)
 }

--- a/internals/secrethub/app.go
+++ b/internals/secrethub/app.go
@@ -100,20 +100,15 @@ func NewApp() *App {
 		logger:          cli.NewLogger(),
 	}
 
-	commandClause := &cli.CommandClause{
-		Cmd: app.cli.Cmd,
-		App: app.cli,
-	}
-
-	app.cli.Cmd.SetUsageFunc(func(command *cobra.Command) error {
-		err := cli.Tmpl(os.Stdout, cli.UsageTemplate, commandClause)
+	app.cli.Cmd.Cmd.SetUsageFunc(func(command *cobra.Command) error {
+		err := cli.Tmpl(os.Stdout, cli.UsageTemplate, app.cli.Cmd)
 		if err != nil {
 			os.Stderr.Write([]byte(err.Error()))
 		}
 		return err
 	})
-	app.cli.Cmd.SetHelpFunc(func(command *cobra.Command, i []string) {
-		err := cli.Tmpl(os.Stdout, cli.HelpTemplate, commandClause)
+	app.cli.Cmd.Cmd.SetHelpFunc(func(command *cobra.Command, i []string) {
+		err := cli.Tmpl(os.Stdout, cli.HelpTemplate, app.cli.Cmd)
 		if err != nil {
 			os.Stderr.Write([]byte(err.Error()))
 		}
@@ -138,7 +133,7 @@ func (app *App) Version(version string, commit string) *App {
 // configures global behavior and executes the command given by the args.
 func (app *App) Run() error {
 	// Parse also executes the command when parsing is successful.
-	err := app.cli.Cmd.Execute()
+	err := app.cli.Cmd.Cmd.Execute()
 	return err
 }
 

--- a/internals/secrethub/app.go
+++ b/internals/secrethub/app.go
@@ -100,15 +100,15 @@ func NewApp() *App {
 		logger:          cli.NewLogger(),
 	}
 
-	app.cli.Cmd.Cmd.SetUsageFunc(func(command *cobra.Command) error {
-		err := cli.Tmpl(os.Stdout, cli.UsageTemplate, app.cli.Cmd)
+	app.cli.Root.Cmd.SetUsageFunc(func(command *cobra.Command) error {
+		err := cli.Tmpl(os.Stdout, cli.UsageTemplate, app.cli.Root)
 		if err != nil {
 			os.Stderr.Write([]byte(err.Error()))
 		}
 		return err
 	})
-	app.cli.Cmd.Cmd.SetHelpFunc(func(command *cobra.Command, i []string) {
-		err := cli.Tmpl(os.Stdout, cli.HelpTemplate, app.cli.Cmd)
+	app.cli.Root.Cmd.SetHelpFunc(func(command *cobra.Command, i []string) {
+		err := cli.Tmpl(os.Stdout, cli.HelpTemplate, app.cli.Root)
 		if err != nil {
 			os.Stderr.Write([]byte(err.Error()))
 		}
@@ -133,7 +133,7 @@ func (app *App) Version(version string, commit string) *App {
 // configures global behavior and executes the command given by the args.
 func (app *App) Run() error {
 	// Parse also executes the command when parsing is successful.
-	err := app.cli.Cmd.Cmd.Execute()
+	err := app.cli.Root.Cmd.Execute()
 	return err
 }
 

--- a/internals/secrethub/client_factory.go
+++ b/internals/secrethub/client_factory.go
@@ -45,7 +45,7 @@ type clientFactory struct {
 // The environment variables of these flags are also checked on the client, but checking them here allows us to fail fast.
 func (f *clientFactory) Register(app *cli.App) {
 	app.PersistentFlags().VarPF(&f.ServerURL, "api-remote", "", "The SecretHub API address, don't set this unless you know what you're doing.")
-	app.Cmd.Flag("api-remote").Hidden = true
+	app.Root.Flag("api-remote").Hidden = true
 	app.PersistentFlags().StringVar(&f.identityProvider, "identity-provider", "key", "Enable native authentication with a trusted identity provider. Options are `aws` (IAM + KMS), `gcp` (IAM + KMS) and `key`. When you run the CLI on one of the platforms, you can leverage their respective identity providers to do native keyless authentication. Defaults to key, which uses the default credential sourced from a file, command-line flag, or environment variable.")
 	app.PersistentFlags().VarPF(&f.proxyAddress, "proxy-address", "", "Set to the address of a proxy to connect to the API through a proxy. The prepended scheme determines the proxy type (http, https and socks5 are supported). For example: `--proxy-address http://my-proxy:1234`")
 }

--- a/internals/secrethub/client_factory.go
+++ b/internals/secrethub/client_factory.go
@@ -44,14 +44,10 @@ type clientFactory struct {
 // Register the flags for configuration on a cli application.
 // The environment variables of these flags are also checked on the client, but checking them here allows us to fail fast.
 func (f *clientFactory) Register(app *cli.App) {
-	commandClause := cli.CommandClause{
-		Cmd: app.Cmd,
-		App: app,
-	}
-	commandClause.PersistentFlags().VarPF(&f.ServerURL, "api-remote", "", "The SecretHub API address, don't set this unless you know what you're doing.")
-	commandClause.Cmd.Flag("api-remote").Hidden = true
-	commandClause.PersistentFlags().StringVar(&f.identityProvider, "identity-provider", "key", "Enable native authentication with a trusted identity provider. Options are `aws` (IAM + KMS), `gcp` (IAM + KMS) and `key`. When you run the CLI on one of the platforms, you can leverage their respective identity providers to do native keyless authentication. Defaults to key, which uses the default credential sourced from a file, command-line flag, or environment variable.")
-	commandClause.PersistentFlags().VarPF(&f.proxyAddress, "proxy-address", "", "Set to the address of a proxy to connect to the API through a proxy. The prepended scheme determines the proxy type (http, https and socks5 are supported). For example: `--proxy-address http://my-proxy:1234`")
+	app.PersistentFlags().VarPF(&f.ServerURL, "api-remote", "", "The SecretHub API address, don't set this unless you know what you're doing.")
+	app.Cmd.Flag("api-remote").Hidden = true
+	app.PersistentFlags().StringVar(&f.identityProvider, "identity-provider", "key", "Enable native authentication with a trusted identity provider. Options are `aws` (IAM + KMS), `gcp` (IAM + KMS) and `key`. When you run the CLI on one of the platforms, you can leverage their respective identity providers to do native keyless authentication. Defaults to key, which uses the default credential sourced from a file, command-line flag, or environment variable.")
+	app.PersistentFlags().VarPF(&f.proxyAddress, "proxy-address", "", "Set to the address of a proxy to connect to the API through a proxy. The prepended scheme determines the proxy type (http, https and socks5 are supported). For example: `--proxy-address http://my-proxy:1234`")
 }
 
 // NewClient returns a new client that is configured to use the remote that

--- a/internals/secrethub/color.go
+++ b/internals/secrethub/color.go
@@ -7,9 +7,5 @@ import (
 
 // RegisterColorFlag registers a color flag that configures whether colored output is used.
 func RegisterColorFlag(app *cli.App) {
-	commandClause := cli.CommandClause{
-		Cmd: app.Cmd,
-		App: app,
-	}
-	commandClause.PersistentFlags().BoolVar(&color.NoColor, "no-color", false, "Disable colored output.")
+	app.PersistentFlags().BoolVar(&color.NoColor, "no-color", false, "Disable colored output.")
 }

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -54,17 +54,13 @@ func (store *credentialConfig) IsPassphraseSet() bool {
 
 // Register registers the flags for configuring the store on the provided Registerer.
 func (store *credentialConfig) Register(app *cli.App) {
-	commandClause := cli.CommandClause{
-		Cmd: app.Cmd,
-		App: app,
-	}
-	commandClause.PersistentFlags().Var(&store.configDir, "config-dir", "The absolute path to a custom configuration directory.")
+	app.PersistentFlags().Var(&store.configDir, "config-dir", "The absolute path to a custom configuration directory.")
 	store.credentialReader = &flagCredentialReader{}
-	store.credentialReader.Flag = commandClause.PersistentFlags().StringVar(&store.credentialReader.value, "credential", "", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.")
-	commandClause.PersistentFlags().StringVarP(&store.credentialPassphrase, "p", "p", "", "").NoEnvar() // Shorthand -p is deprecated. Use --credential-passphrase instead.
-	commandClause.Cmd.Flag("p").Hidden = true
-	commandClause.PersistentFlags().StringVar(&store.credentialPassphrase, "credential-passphrase", "", "The passphrase to unlock your credential file. When set, it will not prompt for the passphrase, nor cache it in the OS keyring. Please only use this if you know what you're doing and ensure your passphrase doesn't end up in bash history.")
-	commandClause.PersistentFlags().DurationVar(&store.CredentialPassphraseCacheTTL, "credential-passphrase-cache-ttl", 5*time.Minute, "Cache the credential passphrase in the OS keyring for this duration. The cache is automatically cleared after the timer runs out. Each time the passphrase is read from the cache the timer is reset. Passphrase caching is turned on by default for 5 minutes. Turn it off by setting the duration to 0.")
+	store.credentialReader.Flag = app.PersistentFlags().StringVar(&store.credentialReader.value, "credential", "", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.")
+	app.PersistentFlags().StringVarP(&store.credentialPassphrase, "p", "p", "", "").NoEnvar() // Shorthand -p is deprecated. Use --credential-passphrase instead.
+	app.Cmd.Flag("p").Hidden = true
+	app.PersistentFlags().StringVar(&store.credentialPassphrase, "credential-passphrase", "", "The passphrase to unlock your credential file. When set, it will not prompt for the passphrase, nor cache it in the OS keyring. Please only use this if you know what you're doing and ensure your passphrase doesn't end up in bash history.")
+	app.PersistentFlags().DurationVar(&store.CredentialPassphraseCacheTTL, "credential-passphrase-cache-ttl", 5*time.Minute, "Cache the credential passphrase in the OS keyring for this duration. The cache is automatically cleared after the timer runs out. Each time the passphrase is read from the cache the timer is reset. Passphrase caching is turned on by default for 5 minutes. Turn it off by setting the duration to 0.")
 }
 
 // Provider retrieves a credential from the store.

--- a/internals/secrethub/credential_store.go
+++ b/internals/secrethub/credential_store.go
@@ -58,7 +58,7 @@ func (store *credentialConfig) Register(app *cli.App) {
 	store.credentialReader = &flagCredentialReader{}
 	store.credentialReader.Flag = app.PersistentFlags().StringVar(&store.credentialReader.value, "credential", "", "Use a specific account credential to authenticate to the API. This overrides the credential stored in the configuration directory.")
 	app.PersistentFlags().StringVarP(&store.credentialPassphrase, "p", "p", "", "").NoEnvar() // Shorthand -p is deprecated. Use --credential-passphrase instead.
-	app.Cmd.Flag("p").Hidden = true
+	app.Root.Flag("p").Hidden = true
 	app.PersistentFlags().StringVar(&store.credentialPassphrase, "credential-passphrase", "", "The passphrase to unlock your credential file. When set, it will not prompt for the passphrase, nor cache it in the OS keyring. Please only use this if you know what you're doing and ensure your passphrase doesn't end up in bash history.")
 	app.PersistentFlags().DurationVar(&store.CredentialPassphraseCacheTTL, "credential-passphrase-cache-ttl", 5*time.Minute, "Cache the credential passphrase in the OS keyring for this duration. The cache is automatically cleared after the timer runs out. Each time the passphrase is read from the cache the timer is reset. Passphrase caching is turned on by default for 5 minutes. Turn it off by setting the duration to 0.")
 }

--- a/internals/secrethub/debug.go
+++ b/internals/secrethub/debug.go
@@ -8,15 +8,10 @@ import (
 
 // RegisterDebugFlag registers a debug flag that changes the log level of the given logger to DEBUG.
 func RegisterDebugFlag(app *cli.App, logger cli.Logger) {
-	commandClause := cli.CommandClause{
-		Cmd: app.Cmd,
-		App: app,
-	}
 	flag := debugFlag{
 		logger: logger,
 	}
-	commandClause.PersistentFlags().VarP(&flag, "debug", "D", "Enable debug mode.")
-	commandClause.Flag("debug").NoOptDefVal = "true"
+	app.PersistentFlags().VarP(&flag, "debug", "D", "Enable debug mode.")
 }
 
 // debugFlag configures the debug level of a logger.

--- a/internals/secrethub/debug.go
+++ b/internals/secrethub/debug.go
@@ -12,7 +12,7 @@ func RegisterDebugFlag(app *cli.App, logger cli.Logger) {
 		logger: logger,
 	}
 	app.PersistentFlags().VarP(&flag, "debug", "D", "Enable debug mode.")
-	app.Cmd.Flag("debug").NoOptDefVal = "true"
+	app.Root.Flag("debug").NoOptDefVal = "true"
 }
 
 // debugFlag configures the debug level of a logger.

--- a/internals/secrethub/debug.go
+++ b/internals/secrethub/debug.go
@@ -12,6 +12,7 @@ func RegisterDebugFlag(app *cli.App, logger cli.Logger) {
 		logger: logger,
 	}
 	app.PersistentFlags().VarP(&flag, "debug", "D", "Enable debug mode.")
+	app.Cmd.Flag("debug").NoOptDefVal = "true"
 }
 
 // debugFlag configures the debug level of a logger.

--- a/internals/secrethub/mlock.go
+++ b/internals/secrethub/mlock.go
@@ -31,6 +31,7 @@ func (f mlockFlag) init() error {
 func RegisterMlockFlag(app *cli.App) {
 	flag := mlockFlag(false)
 	app.PersistentFlags().Var(&flag, "mlock", "Enable memory locking")
+	app.Cmd.Flag("mlock").NoOptDefVal = "true"
 }
 
 // String implements the flag.Value interface.

--- a/internals/secrethub/mlock.go
+++ b/internals/secrethub/mlock.go
@@ -31,7 +31,7 @@ func (f mlockFlag) init() error {
 func RegisterMlockFlag(app *cli.App) {
 	flag := mlockFlag(false)
 	app.PersistentFlags().Var(&flag, "mlock", "Enable memory locking")
-	app.Cmd.Flag("mlock").NoOptDefVal = "true"
+	app.Root.Flag("mlock").NoOptDefVal = "true"
 }
 
 // String implements the flag.Value interface.

--- a/internals/secrethub/mlock.go
+++ b/internals/secrethub/mlock.go
@@ -29,13 +29,8 @@ func (f mlockFlag) init() error {
 
 // RegisterMlockFlag registers a mlock flag that enables memory locking when set to true.
 func RegisterMlockFlag(app *cli.App) {
-	commandClause := cli.CommandClause{
-		Cmd: app.Cmd,
-		App: app,
-	}
 	flag := mlockFlag(false)
-	commandClause.PersistentFlags().Var(&flag, "mlock", "Enable memory locking")
-	commandClause.Flag("mlock").NoOptDefVal = "true"
+	app.PersistentFlags().Var(&flag, "mlock", "Enable memory locking")
 }
 
 // String implements the flag.Value interface.


### PR DESCRIPTION
This PR adds a pre-run hook to all cobra commands that sets all unset flags to their corresponding environment variable's value. This also works in the case of persistent flags.

This PR introduces the limitation of registering all persistent flags on the root command.