### PR TITLE
Replace completion flag from kingpin with cobra's completion command

### DIFF
--- a/internals/secrethub/completion.go
+++ b/internals/secrethub/completion.go
@@ -1,7 +1,6 @@
 package secrethub
 
 import (
-	"bytes"
 	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
@@ -21,7 +20,7 @@ func NewCompletionCommand() *CompletionCommand {
 
 // Register registers the command, arguments and flags on the provided Registerer.
 func (cmd *CompletionCommand) Register(r cli.Registerer) {
-	cmd.clause = r.Command("autocomplete", "Generate completion script")
+	cmd.clause = r.Command("completion", "Generate completion script").Hidden()
 	cmd.clause.Cmd.DisableFlagsInUseLine = true
 	cmd.clause.Cmd.ValidArgs = []string{"bash", "zsh", "fish", "powershell"}
 	cmd.clause.BindAction(cmd.run)
@@ -31,102 +30,13 @@ func (cmd *CompletionCommand) Register(r cli.Registerer) {
 func (cmd *CompletionCommand) run() error {
 	switch cmd.shell.Param {
 	case "bash":
-		//options := []string{"yes", "y", ""}
-		//ok := false
-		//answer, err := ui.Ask(ui.NewUserIO(), "In order to install autocompletion, sudo privileges are needed. Do you agree to give permission? [yes/no]\n")
-		//if err != nil {
-		//	return err
-		//}
-		//for _, a := range options {
-		//	if a == answer {
-		//		ok = true
-		//	}
-		//}
-		//if !ok {
-		//	return nil
-		//}
-		buf := new(bytes.Buffer)
-		buf.Write([]byte("#!/usr/bin/env bash\n"))
-		err := cmd.clause.Cmd.Root().GenBashCompletion(buf)
-		if err != nil {
-			return err
-		}
-		f, err := os.OpenFile("contrib/completion/bash/secrethub", os.O_RDWR|os.O_CREATE, 0755)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-		f.Close()
-		//err = exec.Command("sudo", "mv", "secrethub", "/etc/bash_completion.d/secrethub").Run()
-		//if err != nil {
-		//	return err
-		//}
-		//err = exec.Command("chmod", "+x", "/etc/bash_completion.d/secrethub").Run()
-		//if err != nil {
-		//	return err
-		//}
-		//fmt.Println("Generation complete. From the next terminal onward you will have autocompletion.")
-		//fmt.Println("Please execute the following command To have autocompletion on the current command:\n  source /etc/bash_completion.d/secrethub")
+		_ = cmd.clause.Cmd.Root().GenBashCompletion(os.Stdout)
 	case "zsh":
-		buf := new(bytes.Buffer)
-		err := cmd.clause.Cmd.Root().GenZshCompletion(buf)
-		if err != nil {
-			return err
-		}
-		f, err := os.OpenFile("contrib/completion/zsh/_secrethub", os.O_RDWR|os.O_CREATE, 0755)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-		f.Close()
-		//exec.Command("zsh", "-c", fmt.Sprint("echo", "\"autoload -U compinit; compinit\"", ">>", "~/.zshrc"))
-		//path, err := exec.Command("zsh", "-c", fmt.Sprintf("\"echo %q\"", "${fpath[1]}")).Output()
-		//if err != nil {
-		//	return err
-		//}
-		//fmt.Println(path)
-		//_, err = os.Create(string(path) + "/_secrethub")
-		//if err != nil {
-		//	return err
-		//}
-		//f.Write(buf.Bytes())
-		//defer f.Close()
+		_ = cmd.clause.Cmd.Root().GenZshCompletion(os.Stdout)
 	case "fish":
-		buf := new(bytes.Buffer)
-		err := cmd.clause.Cmd.Root().GenFishCompletion(buf, true)
-		if err != nil {
-			return err
-		}
-		f, err := os.OpenFile("contrib//completion/fish/secrethub.fish", os.O_RDWR|os.O_CREATE, 0755)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-		f.Close()
+		_ = cmd.clause.Cmd.Root().GenFishCompletion(os.Stdout, true)
 	case "powershell":
-		buf := new(bytes.Buffer)
-		err := cmd.clause.Cmd.Root().GenPowerShellCompletion(buf)
-		if err != nil {
-			return err
-		}
-		f, err := os.OpenFile("contrib/completion/powershell/secrethub", os.O_RDWR|os.O_CREATE, 0755)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(buf.Bytes())
-		if err != nil {
-			return err
-		}
-		f.Close()
+		_ = cmd.clause.Cmd.Root().GenPowerShellCompletion(os.Stdout)
 	}
 	return nil
 }

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -9,5 +9,5 @@ fi
 
 if [ "${BASH_COMPLETION_DIR}" != "" ] && [ -d ${BASH_COMPLETION_DIR} ]; then
     echo "Installing completion for Bash"
-    /usr/bin/secrethub --completion-script-bash > ${BASH_COMPLETION_DIR}/secrethub
+    /usr/bin/secrethub completion bash > ${BASH_COMPLETION_DIR}/secrethub
 fi


### PR DESCRIPTION
This PR contains a small fix which will replace the completion script from kingpin to the one provided by cobra for `.deb` and `.rpm` packages. In this way, the error of `unknown flag` visible in bash will be solved.