### PR TITLE
Skip path if the person in org does not have any permissions

### DIFF
--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -272,6 +272,9 @@ func (cmd *MigratePlanCommand) addDirToPlan(client secrethub.ClientInterface, pa
 		}
 		return nil
 	}
+	if err != nil {
+		return err
+	}
 
 	err = addTreeToPlan(tree, plan)
 	if err != nil {

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -256,7 +256,7 @@ func (cmd *MigratePlanCommand) addDirToPlan(client secrethub.ClientInterface, pa
 	fmt.Fprintf(cmd.io.Output(), "Planning migration for %s\n", path)
 
 	tree, err := client.Dirs().GetTree(path, -1, false)
-	if err == api.ErrForbidden {
+	if err == api.ErrForbidden || api.IsErrNotFound(err) {
 		fmt.Fprintf(os.Stderr, "WARN: Skipping '%s' because you do not have read access. ", path)
 		accessLevels, err := client.AccessRules().ListLevels(path)
 		if err == nil {
@@ -270,10 +270,6 @@ func (cmd *MigratePlanCommand) addDirToPlan(client secrethub.ClientInterface, pa
 		} else {
 			fmt.Fprint(os.Stderr, "Ask an admin to migrate the skipped secrets.\n")
 		}
-		return nil
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: Skipping '%s' because it is either not valid or you do not have read access. Ask an admin to migrate the skipped secrets if the path is valid.\n", path)
 		return nil
 	}
 

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -257,7 +257,7 @@ func (cmd *MigratePlanCommand) addDirToPlan(client secrethub.ClientInterface, pa
 
 	tree, err := client.Dirs().GetTree(path, -1, false)
 	if err == api.ErrForbidden {
-		fmt.Fprintf(os.Stderr, "WARN: Skipping %s because you do not have read access. ", path)
+		fmt.Fprintf(os.Stderr, "WARN: Skipping '%s' because you do not have read access. ", path)
 		accessLevels, err := client.AccessRules().ListLevels(path)
 		if err == nil {
 			var usernames []string
@@ -273,7 +273,8 @@ func (cmd *MigratePlanCommand) addDirToPlan(client secrethub.ClientInterface, pa
 		return nil
 	}
 	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "WARN: Skipping '%s' because it is either not valid or you do not have read access. Ask an admin to migrate the skipped secrets if the path is valid.\n", path)
+		return nil
 	}
 
 	err = addTreeToPlan(tree, plan)


### PR DESCRIPTION
Before the migration tool would fail if the path was not valid. Sometimes, the path is valid (e.g. a repo), however the user does not have any permissions set for that specific repo, even though they are a member of the organization owning the repo.

Now the migration tool will just skip it with a warning.