### PR TITLE
Fix tests using WriteClipboardAutoClear

### DIFF
--- a/internals/secrethub/clear_clipboard.go
+++ b/internals/secrethub/clear_clipboard.go
@@ -62,21 +62,30 @@ func (cmd *ClearClipboardCommand) Run() error {
 	return nil
 }
 
-// WriteClipboardAutoClear writes data to the clipboard and clears it after the timeout.
-func WriteClipboardAutoClear(data []byte, timeout time.Duration, clipper clip.Clipper) error {
+type ClipboardWriter interface {
+	Write(data []byte) error
+}
+
+type ClipboardWriterAutoClear struct {
+	timeout time.Duration
+	clipper clip.Clipper
+}
+
+// Write writes data to the clipboard and clears it after the timeout.
+func (clipWriter *ClipboardWriterAutoClear) Write(data []byte) error {
 	hash, err := bcrypt.GenerateFromPassword(data, bcrypt.DefaultCost)
 	if err != nil {
 		return err
 	}
 
-	err = clipper.WriteAll(data)
+	err = clipWriter.clipper.WriteAll(data)
 	if err != nil {
 		return err
 	}
 
 	err = cloneproc.Spawn(
 		"clipboard-clear", hex.EncodeToString(hash),
-		"--timeout", timeout.String())
+		"--timeout", clipWriter.timeout.String())
 
 	return err
 }

--- a/internals/secrethub/clear_clipboard.go
+++ b/internals/secrethub/clear_clipboard.go
@@ -11,8 +11,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// defaultClearClipboardAfter defines the default TTL for data written to the clipboard.
-const defaultClearClipboardAfter = 45 * time.Second
+// clearClipboardAfter defines the TTL for data written to the clipboard.
+const clearClipboardAfter = 45 * time.Second
 
 // ClearClipboardCommand is a command to clear the contents of the clipboard after some time passed.
 type ClearClipboardCommand struct {
@@ -67,7 +67,6 @@ type ClipboardWriter interface {
 }
 
 type ClipboardWriterAutoClear struct {
-	timeout time.Duration
 	clipper clip.Clipper
 }
 
@@ -85,7 +84,7 @@ func (clipWriter *ClipboardWriterAutoClear) Write(data []byte) error {
 
 	err = cloneproc.Spawn(
 		"clipboard-clear", hex.EncodeToString(hash),
-		"--timeout", clipWriter.timeout.String())
+		"--timeout", clearClipboardAfter.String())
 
 	return err
 }

--- a/internals/secrethub/clear_clipboard_test.go
+++ b/internals/secrethub/clear_clipboard_test.go
@@ -1,0 +1,12 @@
+package secrethub
+
+import "bytes"
+
+type FakeClipboardWriter struct {
+	Buffer bytes.Buffer
+}
+
+func (clipWriter *FakeClipboardWriter) Write(data []byte) error {
+	_, err := clipWriter.Buffer.Write(data)
+	return err
+}

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -55,7 +55,6 @@ func NewGenerateSecretCommand(io ui.IO, newClient newClientFunc) *GenerateSecret
 		newClient: newClient,
 		clipWriter: &ClipboardWriterAutoClear{
 			clipper: clip.NewClipboard(),
-			timeout: defaultClearClipboardAfter,
 		},
 	}
 }
@@ -66,7 +65,7 @@ func (cmd *GenerateSecretCommand) Register(r cli.Registerer) {
 	clause.Flags().VarP(&cmd.lengthFlag, "length", "l", "The length of the generated secret.")
 	clause.Cmd.Flag("length").DefValue = strconv.Itoa(defaultLength)
 	clause.Flags().Var(&cmd.mins, "min", "<charset>:<n> Ensure that the resulting password contains at least n characters from the given character set. Note that adding constraints reduces the strength of the secret. When possible, avoid any constraints.")
-	clause.Flags().BoolVarP(&cmd.copyToClipboard, "clip", "c", false, "Copy the generated value to the clipboard. The clipboard is automatically cleared after "+units.HumanDuration(defaultClearClipboardAfter)+".")
+	clause.Flags().BoolVarP(&cmd.copyToClipboard, "clip", "c", false, "Copy the generated value to the clipboard. The clipboard is automatically cleared after "+units.HumanDuration(clearClipboardAfter)+".")
 	_ = cmd.charsetFlag.Set("alphanumeric")
 	clause.Flags().Var(&cmd.charsetFlag, "charset", "Define the set of characters to randomly generate a password from. Options are all, alphanumeric, numeric, lowercase, uppercase, letters, symbols and human-readable. Multiple character sets can be combined by supplying them in a comma separated list.")
 	clause.Cmd.Flag("charset").DefValue = "alphanumeric"
@@ -155,7 +154,7 @@ func (cmd *GenerateSecretCommand) run() error {
 		fmt.Fprintf(
 			cmd.io.Output(),
 			"The generated value has been copied to the clipboard. It will be cleared after %s.\n",
-			units.HumanDuration(defaultClearClipboardAfter),
+			units.HumanDuration(clearClipboardAfter),
 		)
 	}
 

--- a/internals/secrethub/generate.go
+++ b/internals/secrethub/generate.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli/clip"
@@ -35,28 +34,29 @@ const defaultLength = 22
 
 // GenerateSecretCommand generates a new secret and writes to the output path.
 type GenerateSecretCommand struct {
-	symbolsFlag         bool
-	generator           randchar.Generator
-	io                  ui.IO
-	lengthFlag          intValue
-	firstArg            cli.StringValue
-	secondArg           cli.StringValue
-	lengthArg           intValue
-	charsetFlag         charsetValue
-	mins                minRuleValue
-	copyToClipboard     bool
-	clearClipboardAfter time.Duration
-	clipper             clip.Clipper
-	newClient           newClientFunc
+	symbolsFlag     bool
+	generator       randchar.Generator
+	io              ui.IO
+	lengthFlag      intValue
+	firstArg        cli.StringValue
+	secondArg       cli.StringValue
+	lengthArg       intValue
+	charsetFlag     charsetValue
+	mins            minRuleValue
+	copyToClipboard bool
+	newClient       newClientFunc
+	clipWriter      ClipboardWriter
 }
 
 // NewGenerateSecretCommand creates a new GenerateSecretCommand.
 func NewGenerateSecretCommand(io ui.IO, newClient newClientFunc) *GenerateSecretCommand {
 	return &GenerateSecretCommand{
-		io:                  io,
-		newClient:           newClient,
-		clearClipboardAfter: defaultClearClipboardAfter,
-		clipper:             clip.NewClipboard(),
+		io:        io,
+		newClient: newClient,
+		clipWriter: &ClipboardWriterAutoClear{
+			clipper: clip.NewClipboard(),
+			timeout: defaultClearClipboardAfter,
+		},
 	}
 }
 
@@ -66,7 +66,7 @@ func (cmd *GenerateSecretCommand) Register(r cli.Registerer) {
 	clause.Flags().VarP(&cmd.lengthFlag, "length", "l", "The length of the generated secret.")
 	clause.Cmd.Flag("length").DefValue = strconv.Itoa(defaultLength)
 	clause.Flags().Var(&cmd.mins, "min", "<charset>:<n> Ensure that the resulting password contains at least n characters from the given character set. Note that adding constraints reduces the strength of the secret. When possible, avoid any constraints.")
-	clause.Flags().BoolVarP(&cmd.copyToClipboard, "clip", "c", false, "Copy the generated value to the clipboard. The clipboard is automatically cleared after "+units.HumanDuration(cmd.clearClipboardAfter)+".")
+	clause.Flags().BoolVarP(&cmd.copyToClipboard, "clip", "c", false, "Copy the generated value to the clipboard. The clipboard is automatically cleared after "+units.HumanDuration(defaultClearClipboardAfter)+".")
 	_ = cmd.charsetFlag.Set("alphanumeric")
 	clause.Flags().Var(&cmd.charsetFlag, "charset", "Define the set of characters to randomly generate a password from. Options are all, alphanumeric, numeric, lowercase, uppercase, letters, symbols and human-readable. Multiple character sets can be combined by supplying them in a comma separated list.")
 	clause.Cmd.Flag("charset").DefValue = "alphanumeric"
@@ -147,7 +147,7 @@ func (cmd *GenerateSecretCommand) run() error {
 	fmt.Fprintf(cmd.io.Output(), "A randomly generated secret has been written to %s:%d.\n", path, version.Version)
 
 	if cmd.copyToClipboard {
-		err = WriteClipboardAutoClear(data, cmd.clearClipboardAfter, cmd.clipper)
+		err = cmd.clipWriter.Write(data)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func (cmd *GenerateSecretCommand) run() error {
 		fmt.Fprintf(
 			cmd.io.Output(),
 			"The generated value has been copied to the clipboard. It will be cleared after %s.\n",
-			units.HumanDuration(cmd.clearClipboardAfter),
+			units.HumanDuration(defaultClearClipboardAfter),
 		)
 	}
 

--- a/internals/secrethub/inject.go
+++ b/internals/secrethub/inject.go
@@ -43,7 +43,6 @@ func NewInjectCommand(io ui.IO, newClient newClientFunc) *InjectCommand {
 	return &InjectCommand{
 		clipWriter: &ClipboardWriterAutoClear{
 			clipper: clip.NewClipboard(),
-			timeout: defaultClearClipboardAfter,
 		},
 		osEnv:        os.Environ(),
 		io:           io,
@@ -61,7 +60,7 @@ func (cmd *InjectCommand) Register(r cli.Registerer) {
 		"clip", "c", false,
 		fmt.Sprintf(
 			"Copy the injected template to the clipboard instead of stdout. The clipboard is automatically cleared after %s.",
-			units.HumanDuration(defaultClearClipboardAfter),
+			units.HumanDuration(clearClipboardAfter),
 		))
 	clause.Flags().StringVarP(&cmd.inFile, "in-file", "i", "", "The filename of a template file to inject.")
 	clause.Flags().StringVarP(&cmd.outFile, "out-file", "o", "", "Write the injected template to a file instead of stdout.")
@@ -136,7 +135,7 @@ func (cmd *InjectCommand) Run() error {
 			return err
 		}
 
-		_, err = fmt.Fprintf(cmd.io.Output(), "Copied injected template to clipboard. It will be cleared after %s.\n", units.HumanDuration(defaultClearClipboardAfter))
+		_, err = fmt.Fprintf(cmd.io.Output(), "Copied injected template to clipboard. It will be cleared after %s.\n", units.HumanDuration(clearClipboardAfter))
 		if err != nil {
 			return err
 		}

--- a/internals/secrethub/read.go
+++ b/internals/secrethub/read.go
@@ -34,7 +34,6 @@ func NewReadCommand(io ui.IO, newClient newClientFunc) *ReadCommand {
 	return &ReadCommand{
 		clipWriter: &ClipboardWriterAutoClear{
 			clipper: clip.NewClipboard(),
-			timeout: defaultClearClipboardAfter,
 		},
 		io:            io,
 		newClient:     newClient,
@@ -51,7 +50,7 @@ func (cmd *ReadCommand) Register(r cli.Registerer) {
 		"clip", "c", false,
 		fmt.Sprintf(
 			"Copy the secret value to the clipboard. The clipboard is automatically cleared after %s.",
-			units.HumanDuration(defaultClearClipboardAfter),
+			units.HumanDuration(clearClipboardAfter),
 		),
 	)
 	clause.Flags().StringVarP(&cmd.outFile, "out-file", "o", "", "Write the secret value to this file.")
@@ -84,7 +83,7 @@ func (cmd *ReadCommand) Run() error {
 			cmd.io.Output(),
 			"Copied %s to clipboard. It will be cleared after %s.\n",
 			cmd.path,
-			units.HumanDuration(defaultClearClipboardAfter),
+			units.HumanDuration(clearClipboardAfter),
 		)
 	}
 

--- a/internals/secrethub/read.go
+++ b/internals/secrethub/read.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli/clip"
@@ -19,27 +18,28 @@ import (
 
 // ReadCommand is a command to read a secret.
 type ReadCommand struct {
-	io                  ui.IO
-	path                api.SecretPath
-	useClipboard        bool
-	clearClipboardAfter time.Duration
-	clipper             clip.Clipper
-	outFile             string
-	fileMode            filemode.FileMode
-	noNewLine           bool
-	newClient           newClientFunc
-	writeFileFunc       func(filename string, data []byte, perm os.FileMode) error
+	io            ui.IO
+	path          api.SecretPath
+	useClipboard  bool
+	outFile       string
+	fileMode      filemode.FileMode
+	noNewLine     bool
+	newClient     newClientFunc
+	writeFileFunc func(filename string, data []byte, perm os.FileMode) error
+	clipWriter    ClipboardWriter
 }
 
 // NewReadCommand creates a new ReadCommand.
 func NewReadCommand(io ui.IO, newClient newClientFunc) *ReadCommand {
 	return &ReadCommand{
-		clipper:             clip.NewClipboard(),
-		clearClipboardAfter: defaultClearClipboardAfter,
-		io:                  io,
-		newClient:           newClient,
-		writeFileFunc:       ioutil.WriteFile,
-		fileMode:            filemode.New(0600),
+		clipWriter: &ClipboardWriterAutoClear{
+			clipper: clip.NewClipboard(),
+			timeout: defaultClearClipboardAfter,
+		},
+		io:            io,
+		newClient:     newClient,
+		writeFileFunc: ioutil.WriteFile,
+		fileMode:      filemode.New(0600),
 	}
 }
 
@@ -51,7 +51,7 @@ func (cmd *ReadCommand) Register(r cli.Registerer) {
 		"clip", "c", false,
 		fmt.Sprintf(
 			"Copy the secret value to the clipboard. The clipboard is automatically cleared after %s.",
-			units.HumanDuration(cmd.clearClipboardAfter),
+			units.HumanDuration(defaultClearClipboardAfter),
 		),
 	)
 	clause.Flags().StringVarP(&cmd.outFile, "out-file", "o", "", "Write the secret value to this file.")
@@ -75,7 +75,7 @@ func (cmd *ReadCommand) Run() error {
 	}
 
 	if cmd.useClipboard {
-		err = WriteClipboardAutoClear(secret.Data, cmd.clearClipboardAfter, cmd.clipper)
+		err = cmd.clipWriter.Write(secret.Data)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (cmd *ReadCommand) Run() error {
 			cmd.io.Output(),
 			"Copied %s to clipboard. It will be cleared after %s.\n",
 			cmd.path,
-			units.HumanDuration(cmd.clearClipboardAfter),
+			units.HumanDuration(defaultClearClipboardAfter),
 		)
 	}
 

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -26,16 +26,19 @@ type ServiceInitCommand struct {
 	repo          api.RepoPath
 	credential    *credentials.KeyCreator
 	permission    string
-	clipper       clip.Clipper
 	io            ui.IO
 	newClient     newClientFunc
 	writeFileFunc func(filename string, data []byte, perm os.FileMode) error
+	clipWriter    ClipboardWriter
 }
 
 // NewServiceInitCommand creates a new ServiceInitCommand.
 func NewServiceInitCommand(io ui.IO, newClient newClientFunc) *ServiceInitCommand {
 	return &ServiceInitCommand{
-		clipper:       clip.NewClipboard(),
+		clipWriter: &ClipboardWriterAutoClear{
+			clipper: clip.NewClipboard(),
+			timeout: defaultClearClipboardAfter,
+		},
 		io:            io,
 		newClient:     newClient,
 		writeFileFunc: ioutil.WriteFile,
@@ -80,7 +83,7 @@ func (cmd *ServiceInitCommand) Run() error {
 	}
 
 	if cmd.clip {
-		err = WriteClipboardAutoClear(out, defaultClearClipboardAfter, cmd.clipper)
+		err = cmd.clipWriter.Write(out)
 		if err != nil {
 			return err
 		}

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -37,7 +37,6 @@ func NewServiceInitCommand(io ui.IO, newClient newClientFunc) *ServiceInitComman
 	return &ServiceInitCommand{
 		clipWriter: &ClipboardWriterAutoClear{
 			clipper: clip.NewClipboard(),
-			timeout: defaultClearClipboardAfter,
 		},
 		io:            io,
 		newClient:     newClient,


### PR DESCRIPTION
`WriteClipboardAutoClear` spawns up a process to clear the clipboard, using the args of the current process as the base command. For tests, this caused the test command to be spawned, recursively spawning more test commands.

We somehow got away with this for a very long while, probably because the test executes quickly enough to exit before the stack runs full with processes. However, recently an AUR installation failed because of this bug in the tests, as AUR installations run the tests on installation.

This commit fixes the issue by mocking the calls to `WriteClipboardAutoClear` in the tests and using a fake implementation instead, that doesn't spawn new processes.