### PR TITLE
Add integration migration instructions to the apply success message

### DIFF
--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -481,9 +481,9 @@ func (cmd *MigrateApplyCommand) Run() error {
 		}
 		i++
 	}
-	fmt.Fprintln(cmd.io.Output(), "\n" +
-		"Migration completed successfully.\n" +
-		"Your secrets are now available via 1Password.\n" +
+	fmt.Fprintln(cmd.io.Output(), "\n"+
+		"Migration completed successfully.\n"+
+		"Your secrets are now available via 1Password.\n"+
 		"Learn how to load them using any of the integrations at https://secrethub.io/docs/1password/migration/#integrations")
 
 	return nil

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -481,7 +481,10 @@ func (cmd *MigrateApplyCommand) Run() error {
 		}
 		i++
 	}
-	fmt.Fprintln(cmd.io.Output(), "\nMigration completed successfully. You can now use these secrets from 1password.")
+	fmt.Fprintln(cmd.io.Output(), "\n" +
+		"Migration completed successfully.\n" +
+		"Your secrets are now available via 1Password.\n" +
+		"Learn how to load them using any of the integrations at https://secrethub.io/docs/1password/migration/#integrations")
 
 	return nil
 }


### PR DESCRIPTION
When you're done applying the secrets migration, a logical next step would be to migrate your integrations. Including the link in the  success message makes it easier to follow along with the migration process.