### PR TITLE
Switch 1Password item category used in migration to API credential

### DIFF
--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -30,7 +30,7 @@ func CreateItem(vault string, template *ItemTemplate, title string) error {
 
 	encodedTemplate := base64.RawURLEncoding.EncodeToString(jsonTemplate)
 
-	_, err = execOP("create", "item", "login", "--vault="+vault, encodedTemplate, "title="+title)
+	_, err = execOP("create", "item", "apicredential", "--vault="+vault, encodedTemplate, "title="+title)
 	return err
 }
 


### PR DESCRIPTION
API credential does not have any required fields and it fits better with most of the data stored in SecretHub.