### PR TITLE
Fix `migrate config templates` command

### DIFF
--- a/internals/secrethub/migrate_config_envfile.go
+++ b/internals/secrethub/migrate_config_envfile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
@@ -40,13 +39,7 @@ func (cmd *MigrateConfigEnvfileCommand) Run() error {
 		return err
 	}
 
-	outFile, err := os.Create(".env")
-	if err != nil {
-		return fmt.Errorf("cannot create output .env file: %s", err)
-	}
-	defer outFile.Close()
-
-	replaceCount, err := migrateTemplateTags(bytes.NewBuffer(inFileContents), outFile, refMapping, "%s")
+	replaceCount, err := migrateTemplateTags(bytes.NewBuffer(inFileContents), ".env", refMapping, "%s")
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/migrate_config_references.go
+++ b/internals/secrethub/migrate_config_references.go
@@ -3,6 +3,7 @@ package secrethub
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -60,7 +61,12 @@ func migrateReferences(inFile string, outFile string, mapping referenceMapping) 
 		return nil, fmt.Errorf("no 1Password equivalent present in your migration plan for the following secrets:\n- %s", strings.Join(misses, "\n- "))
 	}
 
-	err = ioutil.WriteFile(outFile, []byte(output), 0666)
+	inFileInfo, err := os.Stat(inFile)
+	if err != nil {
+		return nil, ErrReadFile(inFile, err)
+	}
+
+	err = ioutil.WriteFile(outFile, []byte(output), inFileInfo.Mode())
 	if err != nil {
 		return nil, err
 	}

--- a/internals/secrethub/migrate_config_templates.go
+++ b/internals/secrethub/migrate_config_templates.go
@@ -1,10 +1,9 @@
 package secrethub
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -36,25 +35,30 @@ func (cmd *MigrateConfigTemplatesCommand) Run() error {
 			return ErrReadFile(filepath, err)
 		}
 
-		replaceCount, err := migrateTemplateTags(bytes.NewBuffer(inFileContents), filepath, refMapping, "{{ %s }}")
+		output, replaceCount, err := migrateTemplateTags(string(inFileContents), refMapping, "{{ %s }}")
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(cmd.io.Output(), "Updated %s with %d op:// references\n", filepath, len(replaceCount))
+		inFileInfo, err := os.Stat(filepath)
+		if err != nil {
+			return ErrReadFile(filepath, err)
+		}
+
+		err = ioutil.WriteFile(filepath, []byte(output), inFileInfo.Mode())
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.io.Output(), "Updated %s with %d op:// references\n", filepath, replaceCount)
 	}
 
 	return nil
 }
 
-func migrateTemplateTags(inFile io.Reader, outFile string, mapping referenceMapping, formatString string) ([]string, error) {
-	raw, err := ioutil.ReadAll(inFile)
-	if err != nil {
-		return nil, ErrReadFile(inFile, err)
-	}
-
+func migrateTemplateTags(inFileContents string, mapping referenceMapping, formatString string) (string, int, error) {
 	var hits, misses []string
-	output := regexpSecretTemplateTags.ReplaceAllStringFunc(string(raw), func(templateTag string) string {
+	output := regexpSecretTemplateTags.ReplaceAllStringFunc(inFileContents, func(templateTag string) string {
 		path := regexpSecretTemplatePath.FindString(templateTag)
 		if path == "" {
 			misses = append(misses, templateTag)
@@ -85,15 +89,10 @@ func migrateTemplateTags(inFile io.Reader, outFile string, mapping referenceMapp
 			errMsg += "\nDid you specify every possible value for your template variables? E.g. --var varname1=a,b,c,d --var varname2=x,y,z"
 		}
 
-		return nil, fmt.Errorf(errMsg)
+		return "", 0, fmt.Errorf(errMsg)
 	}
 
-	err = ioutil.WriteFile(outFile, []byte(output), 0666)
-	if err != nil {
-		return nil, err
-	}
-
-	return hits, nil
+	return output, len(hits), nil
 }
 
 type MigrateConfigTemplatesCommand struct {

--- a/internals/secrethub/migrate_config_test.go
+++ b/internals/secrethub/migrate_config_test.go
@@ -1,8 +1,6 @@
 package secrethub
 
 import (
-	"bytes"
-	"io/ioutil"
 	"testing"
 
 	"github.com/secrethub/secrethub-go/internals/assert"
@@ -104,21 +102,20 @@ func TestMigrateTemplates(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			var out string
 			m := referenceMapping(tc.mapping)
 			m.stripSecretHubURIScheme()
 			err := m.addVarPossibilities(tc.vars)
 			assert.OK(t, err)
 
-			_, err = migrateTemplateTags(bytes.NewReader([]byte(tc.in)), "test.yml.tpl", m, "{{ %s }}")
+			out, _, err = migrateTemplateTags(tc.in, m, "{{ %s }}")
 			if tc.expectedErr {
 				assert.Equal(t, err != nil, true)
 				return
 			}
 
 			assert.OK(t, err)
-			res, err := ioutil.ReadFile("test.yml.tpl")
-			assert.OK(t, err)
-			assert.Equal(t, string(res), tc.expected)
+			assert.Equal(t, out, tc.expected)
 		})
 	}
 }
@@ -227,6 +224,7 @@ func TestMigrateEnvfile(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			var out string
 			m := referenceMapping(tc.mapping)
 			m.stripSecretHubURIScheme()
 			err := m.addVarPossibilities(tc.vars)
@@ -238,7 +236,7 @@ func TestMigrateEnvfile(t *testing.T) {
 					return err
 				}
 
-				_, err = migrateTemplateTags(bytes.NewReader([]byte(tc.in)), ".env", m, "%s")
+				out, _, err = migrateTemplateTags(tc.in, m, "%s")
 				return err
 			}()
 
@@ -248,9 +246,7 @@ func TestMigrateEnvfile(t *testing.T) {
 			}
 
 			assert.OK(t, err)
-			res, err := ioutil.ReadFile(".env")
-			assert.OK(t, err)
-			assert.Equal(t, string(res), tc.expected)
+			assert.Equal(t, out, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
The command would throw an error because it did not have write permission for overwriting the provided file.