### PR TITLE
Enable migrating templates without whitespaces

### DIFF
--- a/internals/secrethub/migrate_config_envfile.go
+++ b/internals/secrethub/migrate_config_envfile.go
@@ -39,7 +39,7 @@ func (cmd *MigrateConfigEnvfileCommand) Run() error {
 		return err
 	}
 
-	replaceCount, err := migrateTemplateTags(bytes.NewBuffer(inFileContents), ".env", refMapping, "%s")
+	replaceCount, err := migrateTemplateTags(bytes.NewBuffer(inFileContents), ".env", refMapping, "{{ %s }}")
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/migrate_config_envfile.go
+++ b/internals/secrethub/migrate_config_envfile.go
@@ -39,7 +39,7 @@ func (cmd *MigrateConfigEnvfileCommand) Run() error {
 		return err
 	}
 
-	output, replaceCount, err := migrateTemplateTags(string(inFileContents), refMapping, "{{ %s }}")
+	output, replaceCount, err := migrateTemplateTags(string(inFileContents), refMapping, "%s")
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/migrate_config_templates.go
+++ b/internals/secrethub/migrate_config_templates.go
@@ -56,8 +56,8 @@ func migrateTemplateTags(inFile io.Reader, outFile string, mapping referenceMapp
 	var hits, misses []string
 	output := regexpSecretTemplateTags.ReplaceAllStringFunc(string(raw), func(templateTag string) string {
 		path := regexpSecretTemplateTags.FindStringSubmatch(templateTag)
-		fmt.Println(path)
-		if path[1] == "" {
+
+		if path == nil {
 			misses = append(misses, templateTag)
 			return ""
 		}

--- a/internals/secrethub/migrate_config_templates.go
+++ b/internals/secrethub/migrate_config_templates.go
@@ -55,17 +55,12 @@ func migrateTemplateTags(inFile io.Reader, outFile string, mapping referenceMapp
 
 	var hits, misses []string
 	output := regexpSecretTemplateTags.ReplaceAllStringFunc(string(raw), func(templateTag string) string {
-		path := regexpSecretTemplateTags.FindStringSubmatch(templateTag)
+		path := regexpSecretTemplateTags.FindStringSubmatch(templateTag)[1]
 
-		if path == nil {
-			misses = append(misses, templateTag)
-			return ""
-		}
-
-		opRef, ok := mapping[path[1]]
+		opRef, ok := mapping[path]
 		if !ok {
-			misses = append(misses, path[1])
-			return path[1]
+			misses = append(misses, path)
+			return path
 		}
 
 		hits = append(hits, opRef)

--- a/internals/secrethub/migrate_config_templates.go
+++ b/internals/secrethub/migrate_config_templates.go
@@ -58,7 +58,7 @@ func (cmd *MigrateConfigTemplatesCommand) Run() error {
 
 func migrateTemplateTags(inFileContents string, mapping referenceMapping, formatString string) (string, int, error) {
 	var hits, misses []string
-	output := regexpSecretTemplateTags.ReplaceAllStringFunc(string(raw), func(templateTag string) string {
+	output := regexpSecretTemplateTags.ReplaceAllStringFunc(inFileContents, func(templateTag string) string {
 		path := regexpSecretTemplateTags.FindStringSubmatch(templateTag)[1]
 
 		opRef, ok := mapping[path]

--- a/internals/secrethub/migrate_config_test.go
+++ b/internals/secrethub/migrate_config_test.go
@@ -38,6 +38,50 @@ func TestMigrateTemplates(t *testing.T) {
 				"secrethub://org/repo/dir/password": "op://vault/item/password",
 			},
 		},
+		"json no whitespaces": {
+			in: `
+			{
+				"db_host": "db.internal",
+				"db_user": "{{org/repo/dir/user}}",
+				"db_password": "{{org/repo/dir/password}}",
+				"db_port": 5432
+			}
+			`,
+			expected: `
+			{
+				"db_host": "db.internal",
+				"db_user": "{{ op://vault/item/user }}",
+				"db_password": "{{ op://vault/item/password }}",
+				"db_port": 5432
+			}
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/dir/user":     "op://vault/item/user",
+				"secrethub://org/repo/dir/password": "op://vault/item/password",
+			},
+		},
+		"json one whitespaces": {
+			in: `
+			{
+				"db_host": "db.internal",
+				"db_user": "{{org/repo/dir/user }}",
+				"db_password": "{{ org/repo/dir/password}}",
+				"db_port": 5432
+			}
+			`,
+			expected: `
+			{
+				"db_host": "db.internal",
+				"db_user": "{{ op://vault/item/user }}",
+				"db_password": "{{ op://vault/item/password }}",
+				"db_port": 5432
+			}
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/dir/user":     "op://vault/item/user",
+				"secrethub://org/repo/dir/password": "op://vault/item/password",
+			},
+		},
 		"yaml": {
 			in: `
 			db_host: db.internal
@@ -73,6 +117,52 @@ func TestMigrateTemplates(t *testing.T) {
 			db_host: db.internal
 			db_user: "{{ org/repo/$env/dir/user }}"
 			db_password: {{ org/repo/$env/dir/password }}
+			db_port: 5432
+			`,
+			expected: `
+			db_host: db.internal
+			db_user: "{{ op://vault-$ENV/item/user }}"
+			db_password: {{ op://vault-$ENV/item/password }}
+			db_port: 5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/prod/dir/user":     "op://vault-prod/item/user",
+				"secrethub://org/repo/prod/dir/password": "op://vault-prod/item/password",
+				"secrethub://org/repo/dev/dir/user":      "op://vault-dev/item/user",
+				"secrethub://org/repo/dev/dir/password":  "op://vault-dev/item/password",
+			},
+			vars: map[string][]string{
+				"env": {"dev", "prod"},
+			},
+		},
+		"with vars no whitespaces": {
+			in: `
+			db_host: db.internal
+			db_user: "{{org/repo/$env/dir/user}}"
+			db_password: {{org/repo/$env/dir/password}}
+			db_port: 5432
+			`,
+			expected: `
+			db_host: db.internal
+			db_user: "{{ op://vault-$ENV/item/user }}"
+			db_password: {{ op://vault-$ENV/item/password }}
+			db_port: 5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/prod/dir/user":     "op://vault-prod/item/user",
+				"secrethub://org/repo/prod/dir/password": "op://vault-prod/item/password",
+				"secrethub://org/repo/dev/dir/user":      "op://vault-dev/item/user",
+				"secrethub://org/repo/dev/dir/password":  "op://vault-dev/item/password",
+			},
+			vars: map[string][]string{
+				"env": {"dev", "prod"},
+			},
+		},
+		"with vars one whitespaces": {
+			in: `
+			db_host: db.internal
+			db_user: "{{ org/repo/$env/dir/user}}"
+			db_password: {{org/repo/$env/dir/password }}
 			db_port: 5432
 			`,
 			expected: `
@@ -149,6 +239,42 @@ func TestMigrateEnvfile(t *testing.T) {
 				"secrethub://org/repo/dir/password": "op://vault/item/password",
 			},
 		},
+		"envfile no whitespaces": {
+			in: `
+			DB_HOST=db.internal
+			DB_USER={{org/repo/dir/user}}
+			DB_PASSWORD={{org/repo/dir/password}}
+			DB_PORT=5432
+			`,
+			expected: `
+			DB_HOST=db.internal
+			DB_USER=op://vault/item/user
+			DB_PASSWORD=op://vault/item/password
+			DB_PORT=5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/dir/user":     "op://vault/item/user",
+				"secrethub://org/repo/dir/password": "op://vault/item/password",
+			},
+		},
+		"envfile one whitespace": {
+			in: `
+			DB_HOST=db.internal
+			DB_USER={{org/repo/dir/user }}
+			DB_PASSWORD={{ org/repo/dir/password}}
+			DB_PORT=5432
+			`,
+			expected: `
+			DB_HOST=db.internal
+			DB_USER=op://vault/item/user
+			DB_PASSWORD=op://vault/item/password
+			DB_PORT=5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/dir/user":     "op://vault/item/user",
+				"secrethub://org/repo/dir/password": "op://vault/item/password",
+			},
+		},
 		"with comments": {
 			in: `
 			# Database config
@@ -187,6 +313,52 @@ func TestMigrateEnvfile(t *testing.T) {
 			DB_HOST=db.internal
 			DB_USER={{ org/repo/$env/dir/user }}
 			DB_PASSWORD={{ org/repo/$env/dir/password }}
+			DB_PORT=5432
+			`,
+			expected: `
+			DB_HOST=db.internal
+			DB_USER=op://vault-$ENV/item/user
+			DB_PASSWORD=op://vault-$ENV/item/password
+			DB_PORT=5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/prod/dir/user":     "op://vault-prod/item/user",
+				"secrethub://org/repo/prod/dir/password": "op://vault-prod/item/password",
+				"secrethub://org/repo/dev/dir/user":      "op://vault-dev/item/user",
+				"secrethub://org/repo/dev/dir/password":  "op://vault-dev/item/password",
+			},
+			vars: map[string][]string{
+				"env": {"dev", "prod"},
+			},
+		},
+		"with vars no whitespaces": {
+			in: `
+			DB_HOST=db.internal
+			DB_USER={{org/repo/$env/dir/user}}
+			DB_PASSWORD={{org/repo/$env/dir/password}}
+			DB_PORT=5432
+			`,
+			expected: `
+			DB_HOST=db.internal
+			DB_USER=op://vault-$ENV/item/user
+			DB_PASSWORD=op://vault-$ENV/item/password
+			DB_PORT=5432
+			`,
+			mapping: map[string]string{
+				"secrethub://org/repo/prod/dir/user":     "op://vault-prod/item/user",
+				"secrethub://org/repo/prod/dir/password": "op://vault-prod/item/password",
+				"secrethub://org/repo/dev/dir/user":      "op://vault-dev/item/user",
+				"secrethub://org/repo/dev/dir/password":  "op://vault-dev/item/password",
+			},
+			vars: map[string][]string{
+				"env": {"dev", "prod"},
+			},
+		},
+		"with vars one whitespace": {
+			in: `
+			DB_HOST=db.internal
+			DB_USER={{org/repo/$env/dir/user }}
+			DB_PASSWORD={{ org/repo/$env/dir/password}}
 			DB_PORT=5432
 			`,
 			expected: `


### PR DESCRIPTION
Now it is no longer enforced to have template formats with whitespaces between the path and the curly brackets, such as 
`{{ path/to/secrets }}`

Depends on #389 