### PR TITLE
Add support for 1Password CLI 2 in the migration

### DIFF
--- a/internals/onepassword/cli_v1.go
+++ b/internals/onepassword/cli_v1.go
@@ -1,0 +1,118 @@
+package onepassword
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+type OPV1CLI struct {
+	version string
+	isV2    bool
+}
+
+func (op *OPV1CLI) IsV2() bool {
+	return op.isV2
+}
+
+func (op *OPV1CLI) CreateVault(name string) error {
+	_, err := execOP("create", "vault", name)
+	if err != nil {
+		return fmt.Errorf("could not create vault '%s': %s", name, err)
+	}
+	return nil
+}
+
+func (op *OPV1CLI) CreateItem(vault string, template *ItemTemplate, title string) error {
+	jsonTemplate, err := json.Marshal(template)
+	if err != nil {
+		return err
+	}
+
+	encodedTemplate := base64.RawURLEncoding.EncodeToString(jsonTemplate)
+
+	_, err = execOP("create", "item", "apicredential", "--vault="+vault, encodedTemplate, "title="+title)
+	return err
+}
+
+func (op *OPV1CLI) SetField(vault, item, field, value string) error {
+	_, err := execOP("edit", "item", item, fmt.Sprintf(`%s=%s`, field, value), "--vault="+vault)
+	if err != nil {
+		return fmt.Errorf("could not set field '%s'.'%s'.'%s'", vault, item, field)
+	}
+	return nil
+}
+
+// GetFields returns a title-to-value map of the fields from the first section of the given 1Password item.
+// The rest of the fields are ignored as the migration tool only stores information in the first
+// section of each item.
+func (op *OPV1CLI) GetFields(vault, item string) (map[string]string, error) {
+	opItem := struct {
+		Details ItemTemplate `json:"details"`
+	}{}
+	opItemJSON, err := execOP("get", "item", item, "--vault="+vault)
+	if err != nil {
+		return nil, fmt.Errorf("could not get item '%s'.'%s' from 1Password: %s", vault, item, err)
+	}
+	err = json.Unmarshal(opItemJSON, &opItem)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected format of 1Password item in `op get item` command output: %s", err)
+	}
+
+	fields := make(map[string]string, len(opItem.Details.Sections[0].Fields))
+	for _, field := range opItem.Details.Sections[0].Fields {
+		fields[field.Title] = field.Value
+	}
+	return fields, nil
+}
+
+func (op *OPV1CLI) ExistsVault(vaultName string) (bool, error) {
+	vaultsBytes, err := execOP("list", "vaults")
+	if err != nil {
+		return false, fmt.Errorf("could not list vaults: %s", err)
+	}
+
+	vaultsJSON := make([]struct {
+		UUID string `json:"uuid"`
+		Name string `json:"name"`
+	}, 0)
+
+	err = json.Unmarshal(vaultsBytes, &vaultsJSON)
+	if err != nil {
+		return false, fmt.Errorf("unexpected format of `op list vaults`: %s", vaultsBytes)
+	}
+
+	for _, vault := range vaultsJSON {
+		if vault.Name == vaultName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (op *OPV1CLI) ExistsItemInVault(vault string, itemName string) (bool, error) {
+	itemsBytes, err := execOP("list", "items", "--vault", vault)
+	if err != nil {
+		return false, fmt.Errorf("could not list items in vault %s: %s", vault, err)
+	}
+
+	itemsJSON := make([]struct {
+		Overview struct {
+			Title string `json:"title"`
+		} `json:"overview"`
+	}, 0)
+
+	err = json.Unmarshal(itemsBytes, &itemsJSON)
+	if err != nil {
+		return false, fmt.Errorf("unexpected format of `op list items`: %s", itemsBytes)
+	}
+
+	for _, item := range itemsJSON {
+		if item.Overview.Title == itemName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internals/onepassword/cli_v1.go
+++ b/internals/onepassword/cli_v1.go
@@ -6,13 +6,10 @@ import (
 	"fmt"
 )
 
-type OPV1CLI struct {
-	version string
-	isV2    bool
-}
+type OPV1CLI struct{}
 
 func (op *OPV1CLI) IsV2() bool {
-	return op.isV2
+	return false
 }
 
 func (op *OPV1CLI) CreateVault(name string) error {

--- a/internals/onepassword/cli_v2.go
+++ b/internals/onepassword/cli_v2.go
@@ -91,7 +91,7 @@ func (op *OPV2CLI) ExistsVault(vaultName string) (bool, error) {
 	}
 
 	vaultsJSON := make([]struct {
-		UUID string `json:"uuid"`
+		ID   string `json:"id"`
 		Name string `json:"name"`
 	}, 0)
 

--- a/internals/onepassword/cli_v2.go
+++ b/internals/onepassword/cli_v2.go
@@ -7,13 +7,10 @@ import (
 	"os"
 )
 
-type OPV2CLI struct {
-	version string
-	isV2    bool
-}
+type OPV2CLI struct{}
 
 func (op *OPV2CLI) IsV2() bool {
-	return op.isV2
+	return true
 }
 
 func (op *OPV2CLI) CreateVault(name string) error {

--- a/internals/onepassword/cli_v2.go
+++ b/internals/onepassword/cli_v2.go
@@ -7,16 +7,16 @@ import (
 	"os"
 )
 
-type OPV2Client struct {
+type OPV2CLI struct {
 	version string
 	isV2    bool
 }
 
-func (op *OPV2Client) IsV2() bool {
+func (op *OPV2CLI) IsV2() bool {
 	return op.isV2
 }
 
-func (op *OPV2Client) CreateVault(name string) error {
+func (op *OPV2CLI) CreateVault(name string) error {
 	_, err := execOP("vault", "create", name)
 	if err != nil {
 		return fmt.Errorf("could not create vault '%s': %s", name, err)
@@ -24,7 +24,7 @@ func (op *OPV2Client) CreateVault(name string) error {
 	return nil
 }
 
-func (op *OPV2Client) CreateItem(vault string, template *ItemTemplate, title string) error {
+func (op *OPV2CLI) CreateItem(vault string, template *ItemTemplate, title string) error {
 	jsonTemplate, err := json.Marshal(template)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (op *OPV2Client) CreateItem(vault string, template *ItemTemplate, title str
 	return err
 }
 
-func (op *OPV2Client) SetField(vault, item, field, value string) error {
+func (op *OPV2CLI) SetField(vault, item, field, value string) error {
 	_, err := execOP("item", "edit", item, fmt.Sprintf(`%s=%s`, field, value), "--vault="+vault)
 	if err != nil {
 		return fmt.Errorf("could not set field '%s'.'%s'.'%s'", vault, item, field)
@@ -60,7 +60,7 @@ func (op *OPV2Client) SetField(vault, item, field, value string) error {
 // GetFields returns a title-to-value map of the fields from the first section of the given 1Password item.
 // The rest of the fields are ignored as the migration tool only stores information in the first
 // section of each item.
-func (op *OPV2Client) GetFields(vault, item string) (map[string]string, error) {
+func (op *OPV2CLI) GetFields(vault, item string) (map[string]string, error) {
 	opItem := struct {
 		Fields []v2ItemFieldTemplate `json:"fields"`
 	}{}
@@ -87,7 +87,7 @@ type v2ItemFieldTemplate struct {
 	Value string `json:"value"`
 }
 
-func (op *OPV2Client) ExistsVault(vaultName string) (bool, error) {
+func (op *OPV2CLI) ExistsVault(vaultName string) (bool, error) {
 	vaultsBytes, err := execOP("vault", "list", "--format=json")
 	if err != nil {
 		return false, fmt.Errorf("could not list vaults: %s", err)
@@ -112,7 +112,7 @@ func (op *OPV2Client) ExistsVault(vaultName string) (bool, error) {
 	return false, nil
 }
 
-func (op *OPV2Client) ExistsItemInVault(vault string, itemName string) (bool, error) {
+func (op *OPV2CLI) ExistsItemInVault(vault string, itemName string) (bool, error) {
 	itemsBytes, err := execOP("item", "list", "--vault="+vault, "--format=json")
 	if err != nil {
 		return false, fmt.Errorf("could not list items in vault %s: %s", vault, err)

--- a/internals/onepassword/client_v2.go
+++ b/internals/onepassword/client_v2.go
@@ -1,0 +1,137 @@
+package onepassword
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+type OPV2Client struct {
+	version string
+	isV2    bool
+}
+
+func (op *OPV2Client) IsV2() bool {
+	return op.isV2
+}
+
+func (op *OPV2Client) CreateVault(name string) error {
+	_, err := execOP("vault", "create", name)
+	if err != nil {
+		return fmt.Errorf("could not create vault '%s': %s", name, err)
+	}
+	return nil
+}
+
+func (op *OPV2Client) CreateItem(vault string, template *ItemTemplate, title string) error {
+	jsonTemplate, err := json.Marshal(template)
+	if err != nil {
+		return err
+	}
+
+	tempJSONFile, err := ioutil.TempFile(os.TempDir(), "jsonTemplate-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempJSONFile.Name())
+
+	if _, err = tempJSONFile.Write(jsonTemplate); err != nil {
+		return err
+	}
+
+	_, err = execOP("item", "create", "--category=apicredential", "--vault="+vault, "--template="+tempJSONFile.Name(), "--title="+title)
+	if err != nil {
+		return err
+	}
+
+	err = tempJSONFile.Close()
+	return err
+}
+
+func (op *OPV2Client) SetField(vault, item, field, value string) error {
+	_, err := execOP("item", "edit", item, fmt.Sprintf(`%s=%s`, field, value), "--vault="+vault)
+	if err != nil {
+		return fmt.Errorf("could not set field '%s'.'%s'.'%s'", vault, item, field)
+	}
+	return nil
+}
+
+// GetFields returns a title-to-value map of the fields from the first section of the given 1Password item.
+// The rest of the fields are ignored as the migration tool only stores information in the first
+// section of each item.
+func (op *OPV2Client) GetFields(vault, item string) (map[string]string, error) {
+	opItem := struct {
+		Fields []v2ItemFieldTemplate `json:"fields"`
+	}{}
+	opItemJSON, err := execOP("item", "get", item, "--vault="+vault, "--format=json")
+	if err != nil {
+		return nil, fmt.Errorf("could not get item '%s'.'%s' from 1Password: %s", vault, item, err)
+	}
+	err = json.Unmarshal(opItemJSON, &opItem)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected format of 1Password item in `op get item` command output: %s", err)
+	}
+
+	fields := make(map[string]string, len(opItem.Fields))
+	for _, field := range opItem.Fields {
+		fields[field.Label] = field.Value
+	}
+	return fields, nil
+}
+
+type v2ItemFieldTemplate struct {
+	ID    string `json:"id"`
+	Type  string `json:"type"`
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+func (op *OPV2Client) ExistsVault(vaultName string) (bool, error) {
+	vaultsBytes, err := execOP("vault", "list", "--format=json")
+	if err != nil {
+		return false, fmt.Errorf("could not list vaults: %s", err)
+	}
+
+	vaultsJSON := make([]struct {
+		UUID string `json:"uuid"`
+		Name string `json:"name"`
+	}, 0)
+
+	err = json.Unmarshal(vaultsBytes, &vaultsJSON)
+	if err != nil {
+		return false, fmt.Errorf("unexpected format of `op list vaults`: %s", vaultsBytes)
+	}
+
+	for _, vault := range vaultsJSON {
+		if vault.Name == vaultName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (op *OPV2Client) ExistsItemInVault(vault string, itemName string) (bool, error) {
+	itemsBytes, err := execOP("item", "list", "--vault="+vault, "--format=json")
+	if err != nil {
+		return false, fmt.Errorf("could not list items in vault %s: %s", vault, err)
+	}
+
+	itemsJSON := make([]struct {
+		Title string `json:"title"`
+	}, 0)
+
+	err = json.Unmarshal(itemsBytes, &itemsJSON)
+	if err != nil {
+		return false, fmt.Errorf("unexpected format of `op list items`: %s", itemsBytes)
+	}
+
+	for _, item := range itemsJSON {
+		if item.Title == itemName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -2,7 +2,6 @@ package onepassword
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +13,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-type OPClient interface {
+type OPCLI interface {
 	IsV2() bool
 	CreateVault(name string) error
 	CreateItem(vault string, template *ItemTemplate, title string) error
@@ -24,7 +23,7 @@ type OPClient interface {
 	ExistsItemInVault(vault string, itemName string) (bool, error)
 }
 
-func GetOPClient() (OPClient, error) {
+func GetOPClient() (OPCLI, error) {
 	out, err := execOP("--version")
 	if err != nil {
 		return nil, err
@@ -33,75 +32,15 @@ func GetOPClient() (OPClient, error) {
 	version := strings.TrimSpace(string(out))
 
 	if strings.HasPrefix(version, "2.") {
-		return &OPV2Client{
+		return &OPV2CLI{
 			version: version,
 			isV2:    true,
 		}, nil
 	}
-	return &OPV1Client{
+	return &OPV1CLI{
 		version: version,
 		isV2:    false,
 	}, nil
-}
-
-type OPV1Client struct {
-	version string
-	isV2    bool
-}
-
-func (op *OPV1Client) IsV2() bool {
-	return op.isV2
-}
-
-func (op *OPV1Client) CreateVault(name string) error {
-	_, err := execOP("create", "vault", name)
-	if err != nil {
-		return fmt.Errorf("could not create vault '%s': %s", name, err)
-	}
-	return nil
-}
-
-func (op *OPV1Client) CreateItem(vault string, template *ItemTemplate, title string) error {
-	jsonTemplate, err := json.Marshal(template)
-	if err != nil {
-		return err
-	}
-
-	encodedTemplate := base64.RawURLEncoding.EncodeToString(jsonTemplate)
-
-	_, err = execOP("create", "item", "apicredential", "--vault="+vault, encodedTemplate, "title="+title)
-	return err
-}
-
-func (op *OPV1Client) SetField(vault, item, field, value string) error {
-	_, err := execOP("edit", "item", item, fmt.Sprintf(`%s=%s`, field, value), "--vault="+vault)
-	if err != nil {
-		return fmt.Errorf("could not set field '%s'.'%s'.'%s'", vault, item, field)
-	}
-	return nil
-}
-
-// GetFields returns a title-to-value map of the fields from the first section of the given 1Password item.
-// The rest of the fields are ignored as the migration tool only stores information in the first
-// section of each item.
-func (op *OPV1Client) GetFields(vault, item string) (map[string]string, error) {
-	opItem := struct {
-		Details ItemTemplate `json:"details"`
-	}{}
-	opItemJSON, err := execOP("get", "item", item, "--vault="+vault)
-	if err != nil {
-		return nil, fmt.Errorf("could not get item '%s'.'%s' from 1Password: %s", vault, item, err)
-	}
-	err = json.Unmarshal(opItemJSON, &opItem)
-	if err != nil {
-		return nil, fmt.Errorf("unexpected format of 1Password item in `op get item` command output: %s", err)
-	}
-
-	fields := make(map[string]string, len(opItem.Details.Sections[0].Fields))
-	for _, field := range opItem.Details.Sections[0].Fields {
-		fields[field.Title] = field.Value
-	}
-	return fields, nil
 }
 
 func NewItemTemplate() *ItemTemplate {
@@ -240,55 +179,4 @@ func GetSignInAddress() (string, error) {
 	}
 
 	return "", fmt.Errorf("unexpected format of 1password config file at %s: missing account entry for latest used account", path)
-}
-
-func (op *OPV1Client) ExistsVault(vaultName string) (bool, error) {
-	vaultsBytes, err := execOP("list", "vaults")
-	if err != nil {
-		return false, fmt.Errorf("could not list vaults: %s", err)
-	}
-
-	vaultsJSON := make([]struct {
-		UUID string `json:"uuid"`
-		Name string `json:"name"`
-	}, 0)
-
-	err = json.Unmarshal(vaultsBytes, &vaultsJSON)
-	if err != nil {
-		return false, fmt.Errorf("unexpected format of `op list vaults`: %s", vaultsBytes)
-	}
-
-	for _, vault := range vaultsJSON {
-		if vault.Name == vaultName {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func (op *OPV1Client) ExistsItemInVault(vault string, itemName string) (bool, error) {
-	itemsBytes, err := execOP("list", "items", "--vault", vault)
-	if err != nil {
-		return false, fmt.Errorf("could not list items in vault %s: %s", vault, err)
-	}
-
-	itemsJSON := make([]struct {
-		Overview struct {
-			Title string `json:"title"`
-		} `json:"overview"`
-	}, 0)
-
-	err = json.Unmarshal(itemsBytes, &itemsJSON)
-	if err != nil {
-		return false, fmt.Errorf("unexpected format of `op list items`: %s", itemsBytes)
-	}
-
-	for _, item := range itemsJSON {
-		if item.Overview.Title == itemName {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }

--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -32,15 +32,11 @@ func GetOPClient() (OPCLI, error) {
 	version := strings.TrimSpace(string(out))
 
 	if strings.HasPrefix(version, "2.") {
-		return &OPV2CLI{
-			version: version,
-			isV2:    true,
-		}, nil
+		return &OPV2CLI{}, nil
+	} else if strings.HasPrefix(version, "1.") {
+		return &OPV1CLI{}, nil
 	}
-	return &OPV1CLI{
-		version: version,
-		isV2:    false,
-	}, nil
+	return nil, fmt.Errorf("1password: op version not recognized")
 }
 
 func NewItemTemplate() *ItemTemplate {

--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -86,7 +86,7 @@ type itemFieldTemplate struct {
 }
 
 func execOP(args ...string) ([]byte, error) {
-	command := exec.Command("op1", args...)
+	command := exec.Command("op", args...)
 	command.Stderr = os.Stderr
 	var out bytes.Buffer
 	command.Stdout = &out

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -472,7 +472,7 @@ type change interface {
 
 type vaultCreation struct {
 	vault    string
-	opClient onepassword.OPClient
+	opClient onepassword.OPCLI
 }
 
 func (c vaultCreation) Vault() string {
@@ -491,7 +491,7 @@ type itemCreation struct {
 	vault        string
 	item         string
 	itemTemplate *onepassword.ItemTemplate
-	opClient     onepassword.OPClient
+	opClient     onepassword.OPCLI
 }
 
 func (c itemCreation) Vault() string {
@@ -510,7 +510,7 @@ type itemUpdate struct {
 	vault       string
 	item        string
 	fieldValues map[string]string
-	opClient    onepassword.OPClient
+	opClient    onepassword.OPCLI
 }
 
 func (c itemUpdate) Vault() string {


### PR DESCRIPTION
Users who have the 1Password CLI 2 installed can now migrate from SecretHub to 1Password.

Note: When 1Password CLI 2 is used, it no longer adds the sign-in address in the `1password-migration-plan.yml` file and it will not check whether the address coincides with the one the user is singed in. 