### PR TITLE
Fix item creation with 1Password CLI 2 when migrating secrets from SecretHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ jobs:
       arch:
         type: string
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: GOOS=<< parameters.os >> GOARCH=<< parameters.arch >> go build ./cmd/secrethub
   test:
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ jobs:
       arch:
         type: string
     docker:
-      - image: circleci/golang:1.17
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - run: GOOS=<< parameters.os >> GOARCH=<< parameters.arch >> go build ./cmd/secrethub
   test:
     docker:
-      - image: circleci/golang:1.17
+      - image: circleci/golang:1.18
     steps:
       - checkout
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
       - run: make test
   verify-goreleaser:
     docker:
-      - image: goreleaser/goreleaser:v0.133
+      - image: goreleaser/goreleaser:v1.12.3
     steps:
       - checkout
       - run: goreleaser check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.41.1-alpine
+      - image: golangci/golangci-lint:v1.50.1-alpine
     steps:
       - checkout
       - restore_cache:
@@ -30,13 +30,13 @@ jobs:
       arch:
         type: string
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - run: GOOS=<< parameters.os >> GOARCH=<< parameters.arch >> go build ./cmd/secrethub
   test:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - restore_cache:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ brews:
   - name: secrethub-cli
     ids:
       - default
-    github:
+    tap:
       owner: secrethub
       name: homebrew-tools
     folder: Formula

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/secrethub/secrethub-cli
 
-go 1.14
+go 1.17
 
 require (
 	bitbucket.org/zombiezen/cardcpx v0.0.0-20150417151802-902f68ff43ef
@@ -25,4 +25,33 @@ require (
 	google.golang.org/api v0.26.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
+)
+
+require (
+	cloud.google.com/go v0.57.0 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4 // indirect
+	github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf // indirect
+	github.com/danieljoos/wincred v1.0.2 // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/godbus/dbus v4.1.0+incompatible // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.0 // indirect
+	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
+	github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9 // indirect
+	github.com/mattn/go-shellwords v1.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84 // indirect
+	google.golang.org/grpc v1.29.1 // indirect
+	google.golang.org/protobuf v1.21.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/secrethub/secrethub-cli
 
-go 1.17
+go 1.18
 
 require (
 	bitbucket.org/zombiezen/cardcpx v0.0.0-20150417151802-902f68ff43ef

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/sys v0.2.0
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 	golang.org/x/text v0.3.2
 	google.golang.org/api v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -343,8 +343,9 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internals/cli/clip/fakeclip/clip.go
+++ b/internals/cli/clip/fakeclip/clip.go
@@ -1,4 +1,4 @@
-// +build !production
+//go:build !production
 
 // Package fakeclip provides fake implementations of the clip.Clipper interface
 // to be used for testing.

--- a/internals/cli/cloneproc/spawn_unix.go
+++ b/internals/cli/cloneproc/spawn_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+//go:build linux || darwin
 
 package cloneproc
 

--- a/internals/cli/cobra_template.go
+++ b/internals/cli/cobra_template.go
@@ -378,21 +378,21 @@ func numFlags(flagSet pflag.FlagSet) int {
 
 // UsageTemplate is the custom usage template of the command.
 // Changes in comparison to cobra's default template:
-// 1. Usage section
-//	  a. `[flags]` is placed before the arguments.
-//	  b. All arguments are put in the usage in their proper order.
-//    c. Where applicable, the argument name is replaced with its placeholder.
-// 2. Commands section
-// 	  a. For the root command (`secrethub`) the commands are grouped into
-//		 `Management commands` and `Commands`
-// 2. Flags section
-// 	  a. Flag's type was removed.
-// 	  b. The help text for flags is well divided into its own column, thus
-//		 making the visibility of the flags better.
-// 	  c. At the end of a flag's help text, the name of its environment variable is
-//       displayed between brackets.
-//    d. The section is hidden if the only flag is `--help`.
-// 4. Arguments section (created by us)
+//  1. Usage section
+//     a. `[flags]` is placed before the arguments.
+//     b. All arguments are put in the usage in their proper order.
+//     c. Where applicable, the argument name is replaced with its placeholder.
+//  2. Commands section
+//     a. For the root command (`secrethub`) the commands are grouped into
+//     `Management commands` and `Commands`
+//  2. Flags section
+//     a. Flag's type was removed.
+//     b. The help text for flags is well divided into its own column, thus
+//     making the visibility of the flags better.
+//     c. At the end of a flag's help text, the name of its environment variable is
+//     displayed between brackets.
+//     d. The section is hidden if the only flag is `--help`.
+//  4. Arguments section (created by us)
 var UsageTemplate = `Usage:
 {{if .Cmd.Runnable}} {{(useLine .Cmd .Args)}}{{end}}
 {{- if .Cmd.HasAvailableSubCommands}}  {{ .Cmd.CommandPath}} [command]{{end}}

--- a/internals/cli/masker/stream.go
+++ b/internals/cli/masker/stream.go
@@ -3,7 +3,6 @@ package masker
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 )
@@ -80,7 +79,7 @@ func (s *stream) flush(n int) error {
 			}
 
 			// Drop all bytes until the end of the mask.
-			_, err = s.buf.writeUpToIndex(ioutil.Discard, i+int64(length))
+			_, err = s.buf.writeUpToIndex(io.Discard, i+int64(length))
 			if err != nil {
 				return err
 			}

--- a/internals/cli/mlock/mlock_unavailable.go
+++ b/internals/cli/mlock/mlock_unavailable.go
@@ -1,4 +1,4 @@
-// +build android darwin nacl netbsd plan9 windows
+//go:build android || darwin || nacl || netbsd || plan9 || windows
 
 package mlock
 

--- a/internals/cli/mlock/mlock_unix.go
+++ b/internals/cli/mlock/mlock_unix.go
@@ -1,4 +1,4 @@
-// +build dragonfly freebsd linux openbsd solaris
+//go:build dragonfly || freebsd || linux || openbsd || solaris
 
 package mlock
 

--- a/internals/cli/progress/fakeprogress/progressprinter.go
+++ b/internals/cli/progress/fakeprogress/progressprinter.go
@@ -1,4 +1,4 @@
-// +build !production
+//go:build !production
 
 // Package fakeprogress provides an implementation of the progress.Printer interface
 // to be used in tests.

--- a/internals/cli/ui/ask.go
+++ b/internals/cli/ui/ask.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -74,8 +73,8 @@ func AskSecret(io IO, question string) (string, error) {
 
 // AskMultiline prints out the question and reads back the input until an EOF is reached.
 // The input is displayed to the user.
-func AskMultiline(io IO, question string) ([]byte, error) {
-	promptIn, promptOut, err := io.Prompts()
+func AskMultiline(IO IO, question string) ([]byte, error) {
+	promptIn, promptOut, err := IO.Prompts()
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +84,7 @@ func AskMultiline(io IO, question string) ([]byte, error) {
 		return nil, err
 	}
 
-	raw, err := ioutil.ReadAll(promptIn)
+	raw, err := io.ReadAll(promptIn)
 	if err != nil {
 		return nil, err
 	}

--- a/internals/cli/ui/fakeui/testing.go
+++ b/internals/cli/ui/fakeui/testing.go
@@ -1,4 +1,4 @@
-// +build !production
+//go:build !production
 
 package fakeui
 
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,11 +27,11 @@ type FakeIO struct {
 
 // NewIO creates a new FakeIO with empty buffers.
 func NewIO(t *testing.T) *FakeIO {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	assert.OK(t, err)
-	stdIn, err := ioutil.TempFile(tempDir, "in")
+	stdIn, err := os.CreateTemp(tempDir, "in")
 	assert.OK(t, err)
-	stdOut, err := ioutil.TempFile(tempDir, "out")
+	stdOut, err := os.CreateTemp(tempDir, "out")
 	assert.OK(t, err)
 
 	t.Cleanup(func() {
@@ -82,7 +81,7 @@ func (f *FakeIO) Stdout() *os.File {
 }
 
 func (f *FakeIO) ReadStdout() ([]byte, error) {
-	return ioutil.ReadFile(f.StdOut.Name())
+	return os.ReadFile(f.StdOut.Name())
 }
 
 // Prompts returns the mocked prompts and error.
@@ -99,7 +98,7 @@ func (f *FakeIO) IsOutputPiped() bool {
 }
 
 func (f *FakeIO) ReadSecret() ([]byte, error) {
-	return ioutil.ReadAll(f.PasswordReader)
+	return io.ReadAll(f.PasswordReader)
 }
 
 // FakeReader implements the Reader interface.

--- a/internals/cli/ui/io_unix.go
+++ b/internals/cli/ui/io_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+//go:build darwin || linux
 
 package ui
 

--- a/internals/onepassword/cli_v1.go
+++ b/internals/onepassword/cli_v1.go
@@ -20,7 +20,7 @@ func (op *OPV1CLI) CreateVault(name string) error {
 	return nil
 }
 
-func (op *OPV1CLI) CreateItem(vault string, template *ItemTemplate, title string) error {
+func (op *OPV1CLI) CreateItem(vault string, template ItemTemplate, title string) error {
 	jsonTemplate, err := json.Marshal(template)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (op *OPV1CLI) SetField(vault, item, field, value string) error {
 // section of each item.
 func (op *OPV1CLI) GetFields(vault, item string) (map[string]string, error) {
 	opItem := struct {
-		Details ItemTemplate `json:"details"`
+		Details v1ItemTemplate `json:"details"`
 	}{}
 	opItemJSON, err := execOP("get", "item", item, "--vault="+vault)
 	if err != nil {

--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -16,7 +16,7 @@ import (
 type OPCLI interface {
 	IsV2() bool
 	CreateVault(name string) error
-	CreateItem(vault string, template *ItemTemplate, title string) error
+	CreateItem(vault string, template ItemTemplate, title string) error
 	SetField(vault, item, field, value string) error
 	GetFields(vault, item string) (map[string]string, error)
 	ExistsVault(vaultName string) (bool, error)
@@ -39,8 +39,11 @@ func GetOPClient() (OPCLI, error) {
 	return nil, fmt.Errorf("1password: op version not recognized")
 }
 
-func NewItemTemplate() *ItemTemplate {
-	return &ItemTemplate{
+func NewItemTemplate(client OPCLI) ItemTemplate {
+	if client.IsV2() {
+		return &v2ItemTemplate{}
+	}
+	return &v1ItemTemplate{
 		Sections: []sectionTemplate{
 			{
 				Name:  "",
@@ -50,7 +53,11 @@ func NewItemTemplate() *ItemTemplate {
 	}
 }
 
-type ItemTemplate struct {
+type ItemTemplate interface {
+	AddField(name, value string, concealed bool)
+}
+
+type v1ItemTemplate struct {
 	Sections []sectionTemplate `json:"sections"`
 }
 
@@ -60,7 +67,7 @@ type sectionTemplate struct {
 	Fields []itemFieldTemplate `json:"fields"`
 }
 
-func (tpl *ItemTemplate) AddField(name, value string, concealed bool) {
+func (tpl *v1ItemTemplate) AddField(name, value string, concealed bool) {
 	designation := "concealed"
 	if !concealed {
 		designation = "string"

--- a/internals/onepassword/onepassword.go
+++ b/internals/onepassword/onepassword.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -157,7 +156,7 @@ func GetSignInAddress() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	bytes, err := ioutil.ReadFile(filepath.Join(path, "config"))
+	bytes, err := os.ReadFile(filepath.Join(path, "config"))
 	if err != nil {
 		return "", fmt.Errorf("could not read 1password config file at %s", path)
 	}

--- a/internals/secrethub/clear.go
+++ b/internals/secrethub/clear.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
@@ -45,7 +44,7 @@ func (cmd *ClearCommand) Run() error {
 		return ErrFileNotFound(cmd.in)
 	}
 
-	spec, err := ioutil.ReadFile(cmd.in)
+	spec, err := os.ReadFile(cmd.in)
 	if err != nil {
 		return ErrCannotReadFile(cmd.in, err)
 	}

--- a/internals/secrethub/env_source.go
+++ b/internals/secrethub/env_source.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +52,7 @@ func newEnvironment(io ui.IO, newClient newClientFunc) *environment {
 		io:           io,
 		newClient:    newClient,
 		osEnv:        os.Environ(),
-		readFile:     ioutil.ReadFile,
+		readFile:     os.ReadFile,
 		osStat:       os.Stat,
 		templateVars: make(map[string]string),
 		envar:        make(map[string]string),
@@ -348,7 +347,7 @@ type EnvDir map[string]value
 // NewEnvDir sources environment variables from files in a given directory,
 // using the file name as key and contents as value.
 func NewEnvDir(path string) (EnvDir, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, ErrReadEnvDir(err)
 	}
@@ -357,7 +356,7 @@ func NewEnvDir(path string) (EnvDir, error) {
 	for _, f := range files {
 		if !f.IsDir() {
 			filePath := filepath.Join(path, f.Name())
-			fileContent, err := ioutil.ReadFile(filePath)
+			fileContent, err := os.ReadFile(filePath)
 			if err != nil {
 				return nil, ErrReadEnvFile(f.Name(), err)
 			}
@@ -603,12 +602,12 @@ const (
 // it is wrapped in either single or double quotes.
 //
 // Rules:
-// - Empty values become empty values (e.g. `''`and `""` both evaluate to the empty string ``).
-// - Inner quotes are maintained (e.g. `{"foo":"bar"}` remains unchanged).
-// - Single and double quoted values are escaped (e.g. `'foo'` and `"foo"` both evaluate to `foo`).
-// - Single and double qouted values maintain whitespace from both ends (e.g. `" foo "` becomes ` foo `)
-// - Inputs with either leading or trailing whitespace are considered unquoted,
-//   so make sure you sanitize your inputs before calling this function.
+//   - Empty values become empty values (e.g. `”`and `""` both evaluate to the empty string “).
+//   - Inner quotes are maintained (e.g. `{"foo":"bar"}` remains unchanged).
+//   - Single and double quoted values are escaped (e.g. `'foo'` and `"foo"` both evaluate to `foo`).
+//   - Single and double qouted values maintain whitespace from both ends (e.g. `" foo "` becomes ` foo `)
+//   - Inputs with either leading or trailing whitespace are considered unquoted,
+//     so make sure you sanitize your inputs before calling this function.
 func trimQuotes(s string) (string, bool) {
 	n := len(s)
 	if n > 1 &&
@@ -621,7 +620,7 @@ func trimQuotes(s string) (string, bool) {
 }
 
 func parseYML(r io.Reader) ([]envvar, error) {
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internals/secrethub/fakes/timeformatter.go
+++ b/internals/secrethub/fakes/timeformatter.go
@@ -1,4 +1,4 @@
-// +build !production
+//go:build !production
 
 package fakes
 

--- a/internals/secrethub/init.go
+++ b/internals/secrethub/init.go
@@ -353,7 +353,7 @@ func writeNewCredential(credential *credentials.KeyCreator, passphrase string, c
 		exportKey = exportKey.Passphrase(credentials.FromString(passphrase))
 	}
 
-	encodedCredential, err := credential.Export()
+	encodedCredential, err := exportKey.Export()
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/inject.go
+++ b/internals/secrethub/inject.go
@@ -2,7 +2,7 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -86,7 +86,7 @@ func (cmd *InjectCommand) Run() error {
 	var raw []byte
 
 	if cmd.inFile != "" {
-		raw, err = ioutil.ReadFile(cmd.inFile)
+		raw, err = os.ReadFile(cmd.inFile)
 		if err != nil {
 			return ErrReadFile(cmd.inFile, err)
 		}
@@ -95,7 +95,7 @@ func (cmd *InjectCommand) Run() error {
 			return ErrNoDataOnStdin
 		}
 
-		raw, err = ioutil.ReadAll(cmd.io.Input())
+		raw, err = io.ReadAll(cmd.io.Input())
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func (cmd *InjectCommand) Run() error {
 			}
 		}
 
-		err = ioutil.WriteFile(cmd.outFile, posix.AddNewLine(out), cmd.fileMode.FileMode())
+		err = os.WriteFile(cmd.outFile, posix.AddNewLine(out), cmd.fileMode.FileMode())
 		if err != nil {
 			return ErrCannotWrite(cmd.outFile, err)
 		}

--- a/internals/secrethub/list_formatters.go
+++ b/internals/secrethub/list_formatters.go
@@ -3,6 +3,8 @@ package secrethub
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"io"
 	"strings"
 )
@@ -38,7 +40,8 @@ func newJSONFormatter(writer io.Writer, fieldNames []string) *jsonFormatter {
 }
 
 func toPascalCase(s string) string {
-	return strings.ReplaceAll(strings.Title(s), " ", "")
+	caser := cases.Title(language.English)
+	return strings.ReplaceAll(caser.String(s), " ", "")
 }
 
 type jsonFormatter struct {

--- a/internals/secrethub/list_formatters.go
+++ b/internals/secrethub/list_formatters.go
@@ -3,10 +3,11 @@ package secrethub
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"io"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type listFormatter interface {

--- a/internals/secrethub/main_test.go
+++ b/internals/secrethub/main_test.go
@@ -1,7 +1,6 @@
 package secrethub
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -78,7 +77,7 @@ func (td testDataDir) cleanup() error {
 func (td testDataDir) tempDir(tb testing.TB) (string, func()) {
 	tb.Helper()
 
-	path, err := ioutil.TempDir(td.root, "")
+	path, err := os.MkdirTemp(td.root, "")
 	assert.OK(tb, err)
 
 	// Log it to make debugging easier.

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -490,7 +490,7 @@ func (c vaultCreation) Print(w io.Writer) {
 type itemCreation struct {
 	vault        string
 	item         string
-	itemTemplate *onepassword.ItemTemplate
+	itemTemplate onepassword.ItemTemplate
 	opClient     onepassword.OPCLI
 }
 
@@ -598,7 +598,7 @@ func (cmd *MigrateApplyCommand) Run() error {
 			}
 
 			if !itemExists {
-				template := onepassword.NewItemTemplate()
+				template := onepassword.NewItemTemplate(opClient)
 				for _, field := range item.Fields {
 					value, err := client.Secrets().ReadString(strings.TrimPrefix(field.Reference, secretReferencePrefix))
 					if err != nil {

--- a/internals/secrethub/migrate.go
+++ b/internals/secrethub/migrate.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -292,7 +291,7 @@ func (cmd *MigratePlanCommand) Run() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(cmd.outFile, out, cmd.fileMode.FileMode())
+	err = os.WriteFile(cmd.outFile, out, cmd.fileMode.FileMode())
 	if err != nil {
 		return err
 	}
@@ -721,7 +720,7 @@ func (w indentedWriter) Write(p []byte) (n int, err error) {
 }
 
 func getPlan(planFile string) (*plan, error) {
-	contents, err := ioutil.ReadFile(planFile)
+	contents, err := os.ReadFile(planFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internals/secrethub/migrate_config_envfile.go
+++ b/internals/secrethub/migrate_config_envfile.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -29,7 +28,7 @@ func (cmd *MigrateConfigEnvfileCommand) Run() error {
 		filepath = "secrethub.env"
 	}
 
-	inFileContents, err := ioutil.ReadFile(filepath)
+	inFileContents, err := os.ReadFile(filepath)
 	if err != nil {
 		return ErrReadFile(filepath, err)
 	}
@@ -49,7 +48,7 @@ func (cmd *MigrateConfigEnvfileCommand) Run() error {
 		return ErrReadFile(filepath, err)
 	}
 
-	err = ioutil.WriteFile(".env", []byte(output), inFileInfo.Mode())
+	err = os.WriteFile(".env", []byte(output), inFileInfo.Mode())
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/migrate_config_references.go
+++ b/internals/secrethub/migrate_config_references.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -33,7 +32,7 @@ func (cmd *MigrateConfigReferencesCommand) Run() error {
 }
 
 func migrateReferences(inFile string, outFile string, mapping referenceMapping) ([]string, error) {
-	raw, err := ioutil.ReadFile(inFile)
+	raw, err := os.ReadFile(inFile)
 	if err != nil {
 		return nil, ErrReadFile(inFile, err)
 	}
@@ -66,7 +65,7 @@ func migrateReferences(inFile string, outFile string, mapping referenceMapping) 
 		return nil, ErrReadFile(inFile, err)
 	}
 
-	err = ioutil.WriteFile(outFile, []byte(output), inFileInfo.Mode())
+	err = os.WriteFile(outFile, []byte(output), inFileInfo.Mode())
 	if err != nil {
 		return nil, err
 	}

--- a/internals/secrethub/migrate_config_templates.go
+++ b/internals/secrethub/migrate_config_templates.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -30,7 +29,7 @@ func (cmd *MigrateConfigTemplatesCommand) Run() error {
 	refMapping.stripSecretHubURIScheme()
 
 	for _, filepath := range cmd.inFiles {
-		inFileContents, err := ioutil.ReadFile(filepath)
+		inFileContents, err := os.ReadFile(filepath)
 		if err != nil {
 			return ErrReadFile(filepath, err)
 		}
@@ -45,7 +44,7 @@ func (cmd *MigrateConfigTemplatesCommand) Run() error {
 			return ErrReadFile(filepath, err)
 		}
 
-		err = ioutil.WriteFile(filepath, []byte(output), inFileInfo.Mode())
+		err = os.WriteFile(filepath, []byte(output), inFileInfo.Mode())
 		if err != nil {
 			return err
 		}

--- a/internals/secrethub/profile_dir_test.go
+++ b/internals/secrethub/profile_dir_test.go
@@ -1,7 +1,7 @@
 package secrethub
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestIsOldConfiguration(t *testing.T) {
 			defer cleanup()
 
 			for _, file := range tc.files {
-				err := ioutil.WriteFile(filepath.Join(dir, file), []byte("test data"), 0770)
+				err := os.WriteFile(filepath.Join(dir, file), []byte("test data"), 0770)
 				assert.OK(t, err)
 			}
 

--- a/internals/secrethub/read.go
+++ b/internals/secrethub/read.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
@@ -37,7 +36,7 @@ func NewReadCommand(io ui.IO, newClient newClientFunc) *ReadCommand {
 		},
 		io:            io,
 		newClient:     newClient,
-		writeFileFunc: ioutil.WriteFile,
+		writeFileFunc: os.WriteFile,
 		fileMode:      filemode.New(0600),
 	}
 }

--- a/internals/secrethub/run_test.go
+++ b/internals/secrethub/run_test.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -1231,7 +1230,7 @@ func TestRunCommand_RunWithFile(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if tc.script != "" {
 				scriptFile := filepath.Join(os.TempDir(), tc.command.command[1])
-				err := ioutil.WriteFile(scriptFile, []byte(tc.script), os.ModePerm)
+				err := os.WriteFile(scriptFile, []byte(tc.script), os.ModePerm)
 				if err != nil {
 					log.Fatal("Cannot create file for test", err)
 				}

--- a/internals/secrethub/service_deploy_winrm.go
+++ b/internals/secrethub/service_deploy_winrm.go
@@ -3,7 +3,7 @@ package secrethub
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 
@@ -98,7 +98,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 
 	var caCert []byte
 	if cmd.caCert != "" {
-		caCert, err = ioutil.ReadFile(cmd.caCert)
+		caCert, err = os.ReadFile(cmd.caCert)
 		if err != nil {
 			return ErrCouldNotReadCA(err)
 		}
@@ -148,14 +148,14 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 	case "cert":
 		var clientCert, clientKey []byte
 		if cmd.clientCert != "" {
-			clientCert, err = ioutil.ReadFile(cmd.clientCert)
+			clientCert, err = os.ReadFile(cmd.clientCert)
 			if err != nil {
 				return ErrCouldNotReadCert(err)
 			}
 		}
 
 		if cmd.clientKey != "" {
-			clientKey, err = ioutil.ReadFile(cmd.clientKey)
+			clientKey, err = os.ReadFile(cmd.clientKey)
 			if err != nil {
 				return ErrCouldNotReadKey(err)
 			}
@@ -187,7 +187,7 @@ func (cmd *ServiceDeployWinRmCommand) Run() error {
 		return ErrNoDataOnStdin
 	}
 
-	credential, err := ioutil.ReadAll(cmd.io.Input())
+	credential, err := io.ReadAll(cmd.io.Input())
 	if err != nil {
 		return err
 	}

--- a/internals/secrethub/service_init.go
+++ b/internals/secrethub/service_init.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -40,7 +39,7 @@ func NewServiceInitCommand(io ui.IO, newClient newClientFunc) *ServiceInitComman
 		},
 		io:            io,
 		newClient:     newClient,
-		writeFileFunc: ioutil.WriteFile,
+		writeFileFunc: os.WriteFile,
 		credential:    credentials.CreateKey(),
 	}
 }

--- a/internals/secrethub/set.go
+++ b/internals/secrethub/set.go
@@ -2,7 +2,6 @@ package secrethub
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/secrethub/secrethub-go/internals/api"
@@ -56,7 +55,7 @@ func (cmd *SetCommand) Run() error {
 		return ErrFileNotFound(cmd.in)
 	}
 
-	spec, err := ioutil.ReadFile(cmd.in)
+	spec, err := os.ReadFile(cmd.in)
 	if err != nil {
 		return ErrCannotReadFile(cmd.in, err)
 	}

--- a/internals/secrethub/tpl/v2.go
+++ b/internals/secrethub/tpl/v2.go
@@ -84,17 +84,17 @@ type parserV2 struct{}
 // Parse parses a secret template from a raw string.
 //
 // Syntax rules:
-// - A secret template can contain references to secrets in secret tags. A
-//   secret tag is enclosed in double brackets: `{{ path/to/secret }}`.
-// - A secret template can contain references to variables in variable tags. A
-//   variable tag is enclosed between ${ and }: `${ variable }`.
-// - Extra spaces can be added just after the opening delimiter and just before the
-//   closing delimiter of a tag: {{ path/to/secret }} has the same output as
-//   {{path/to/secret}} has.
-// - Secret tags can also contain variable tags: `{{ path/with/${var}/to/secret }}`
-// - Variable tags cannot contain secret tags.
-// - Secret tags cannot contain secret tags (they cannot be nested).
-// - Variable tags cannot contain variable tags (they cannot be nested).
+//   - A secret template can contain references to secrets in secret tags. A
+//     secret tag is enclosed in double brackets: `{{ path/to/secret }}`.
+//   - A secret template can contain references to variables in variable tags. A
+//     variable tag is enclosed between ${ and }: `${ variable }`.
+//   - Extra spaces can be added just after the opening delimiter and just before the
+//     closing delimiter of a tag: {{ path/to/secret }} has the same output as
+//     {{path/to/secret}} has.
+//   - Secret tags can also contain variable tags: `{{ path/with/${var}/to/secret }}`
+//   - Variable tags cannot contain secret tags.
+//   - Secret tags cannot contain secret tags (they cannot be nested).
+//   - Variable tags cannot contain variable tags (they cannot be nested).
 func (p parserV2) Parse(raw string, line, column int) (Template, error) {
 	parser := newV2Parser(bytes.NewBufferString(raw), line, column)
 

--- a/internals/secrethub/write.go
+++ b/internals/secrethub/write.go
@@ -3,7 +3,8 @@ package secrethub
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/secrethub/secrethub-cli/internals/cli"
 	"github.com/secrethub/secrethub-cli/internals/cli/clip"
@@ -78,12 +79,12 @@ func (cmd *WriteCommand) Run() error {
 			return err
 		}
 	} else if cmd.inFile != "" {
-		data, err = ioutil.ReadFile(cmd.inFile)
+		data, err = os.ReadFile(cmd.inFile)
 		if err != nil {
 			return ErrReadFile(cmd.inFile, err)
 		}
 	} else if cmd.io.IsInputPiped() {
-		data, err = ioutil.ReadAll(cmd.io.Input())
+		data, err = io.ReadAll(cmd.io.Input())
 		if err != nil {
 			return ui.ErrReadInput(err)
 		}

--- a/internals/secretspec/consumable.go
+++ b/internals/secretspec/consumable.go
@@ -1,7 +1,6 @@
 package secretspec
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -254,7 +253,7 @@ func overwriteFile(filename string, data []byte, perm os.FileMode) error {
 			return ErrCannotOverwriteFile(filename, err)
 		}
 	}
-	err = ioutil.WriteFile(filename, data, perm)
+	err = os.WriteFile(filename, data, perm)
 	if err != nil {
 		return ErrCannotOverwriteFile(filename, err)
 	}

--- a/internals/secretspec/env_test.go
+++ b/internals/secretspec/env_test.go
@@ -1,7 +1,6 @@
 package secretspec
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -400,7 +399,7 @@ func TestEnvSetAndClear(t *testing.T) {
 
 			if tc.err == nil {
 				for target, expected := range tc.expected {
-					actual, err := ioutil.ReadFile(filepath.Join(env.dirPath, target))
+					actual, err := os.ReadFile(filepath.Join(env.dirPath, target))
 					if err != nil {
 						t.Errorf("cannot read file: %v", err)
 					} else {

--- a/internals/secretspec/file_test.go
+++ b/internals/secretspec/file_test.go
@@ -1,7 +1,6 @@
 package secretspec
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -279,7 +278,7 @@ func TestFileSetAndClear(t *testing.T) {
 			}
 
 			if tc.err == nil {
-				actual, err := ioutil.ReadFile(tc.target)
+				actual, err := os.ReadFile(tc.target)
 				if err != nil {
 					t.Errorf("cannot read file: %v", err)
 				} else {

--- a/internals/secretspec/inject.go
+++ b/internals/secretspec/inject.go
@@ -2,7 +2,6 @@ package secretspec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -72,7 +71,7 @@ func (p InjectParser) Parse(rootPath string, allowMountAnywhere bool, config map
 	}
 
 	// Read and parse the file to inject.
-	bytes, err := ioutil.ReadFile(source)
+	bytes, err := os.ReadFile(source)
 	if err != nil {
 		return nil, ErrCannotReadFile(source, err)
 	}

--- a/internals/secretspec/inject_test.go
+++ b/internals/secretspec/inject_test.go
@@ -1,7 +1,6 @@
 package secretspec_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -60,7 +59,7 @@ func TestInjectSetClear(t *testing.T) {
 	}
 
 	// write a config to inject
-	err = ioutil.WriteFile("test-config.json", []byte(testConfigJSONToInject), 0644)
+	err = os.WriteFile("test-config.json", []byte(testConfigJSONToInject), 0644)
 	if err != nil {
 		t.Fatalf("could not write test config to inject: %s", err)
 	}
@@ -84,7 +83,7 @@ func TestInjectSetClear(t *testing.T) {
 		t.Fatalf("cannot set presenter: %s", err)
 	}
 
-	actual, err := ioutil.ReadFile("test-config-injected.json")
+	actual, err := os.ReadFile("test-config-injected.json")
 	if err != nil {
 		t.Fatalf("cannot read from consumable file: %s", err)
 	}

--- a/internals/winrm/client.go
+++ b/internals/winrm/client.go
@@ -46,7 +46,7 @@ type Config struct {
 	CaCert         []byte
 }
 
-/// authMethod gives an interface to retrieve the valid credentials or defaults.
+// authMethod gives an interface to retrieve the valid credentials or defaults.
 // The Client always needs both values for certificates authentication and basic authentication.
 // So we use implementations of this interface to give us the values without having to know the implementation.
 // The necessity of this is because of the weird interface giving by our dependency on the masterzen/winrm library.

--- a/internals/winrm/copy.go
+++ b/internals/winrm/copy.go
@@ -22,9 +22,9 @@ var (
 
 // doCopy copies the contents from the io.Reader into the to path.
 // The copy process is done in multiple steps:
-//     1. The content is uploaded to a temporary file in chunks
-//     2. The content is restored from the chunks into a single file at the target location.
-//     3. The temporary file is removed.
+//  1. The content is uploaded to a temporary file in chunks
+//  2. The content is restored from the chunks into a single file at the target location.
+//  3. The temporary file is removed.
 //
 // Progress is reported in the progress channel given as a variable.
 func doCopy(client *winrm.Client, in io.Reader, toPath string, progress chan int) error {
@@ -75,7 +75,7 @@ func uploadContent(client *winrm.Client, maxChunks int, filePath string, reader 
 }
 
 // uploadChunks uploads the content by dividing the content into multiple chunks.
-// The chunks are combined into a single file.
+//  The chunks are combined into a single file.
 // The chunks are used to get around the maximum command line size limit.
 // This allows us to use the winRM connection for uploading files.
 func uploadChunks(client *winrm.Client, filePath string, maxChunks int, reader io.Reader) (done bool, err error) {


### PR DESCRIPTION
The bug came from the fact that 1Password CLI 2 no longer supports old item templates as input. Therefore, we now have to use the new item JSON template to make it work.

Files that fix the bug and actually require a review:
- `internals/onepassword/onepassword.go`
- `internals/onepassword/cli_v1.go`
- `internals/onepassword/cli_v2.go`
- `internals/secrethub/migrate.go`

Summary of other changes:
- Change `build` tags to newer version (i.e. from `+build` to `go:build`)
- Replace deprecated functions from `ioutil`
- Update a go dependency which enables building the CLI on arm64
- Update Go version used by the package and the pipeline to 1.18 for the following reasons:
  - Go 1.18 is safe for changing `build` tags (i.e. no change of errors for not having both tags)
  - The updated Go dependency requires Go 1.17 or higher
- Update go releaser image used in pipeline. This involved making a config change in the `.goreleaser.yaml` to be compliant to the new syntax. Check [this documentation](https://goreleaser.com/deprecations/?h=brews#brewsgithub) for understanding the change 
- Address other lint errors